### PR TITLE
feat: replay animations on scroll

### DIFF
--- a/components/AnimatedSection.tsx
+++ b/components/AnimatedSection.tsx
@@ -9,7 +9,7 @@ export default function AnimatedSection({ children, className = "" }: { children
       className={className}
       initial={prefersReduced ? false : { opacity: 0, y: 20 }}
       whileInView={prefersReduced ? {} : { opacity: 1, y: 0 }}
-      viewport={{ once: true, amount: 0.2 }}
+      viewport={{ once: false, amount: 0.2 }}
       transition={{ duration: 0.5 }}
     >
       {children}

--- a/components/Reveal.tsx
+++ b/components/Reveal.tsx
@@ -16,7 +16,7 @@ export default function Reveal({ children, delay = 0.1, className }: RevealProps
       className={className}
       initial={prefersReduced ? false : { opacity: 0, y: 16 }}
       whileInView={prefersReduced ? {} : { opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: "-80px" }}
+      viewport={{ once: false, margin: "-80px" }}
       transition={{ duration: 0.6, delay }}
     >
       {children}


### PR DESCRIPTION
## Wat
- maak viewport-triggered animaties herhaalbaar bij scrollen

## Waarom
- animaties moeten niet alleen bij page load starten maar ook opnieuw bij op- en neer scrollen

## Testplan
- [x] Build OK
- [x] Lint OK
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video


------
https://chatgpt.com/codex/tasks/task_b_68acc70c6ed08332ae6c062e2bf33468