### PR TITLE
feat: add about page

### DIFF
--- a/app/(pages)/about/page.tsx
+++ b/app/(pages)/about/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Over X3DPrints | 3D Printstudio in Herzele",
+  description:
+    "Maak kennis met X3DPrints, de 3D-printstudio uit Herzele voor prototypes en kleine series in PLA, PETG of TPU. Persoonlijk advies en snelle levering.",
+};
+
+export default function Page() {
+  return (
+    <section className="container mx-auto max-w-3xl py-12">
+      <h1 className="text-3xl font-semibold tracking-tight">Over X3DPrints</h1>
+      <p className="mt-4 text-muted-foreground">
+        X3DPrints is een lokale 3D-printstudio in Herzele. Als onderdeel van Xinudesign maken we 3D-printen
+        betaalbaar en toegankelijk. We werken met professionele Bambu Lab FDM-printers en bieden een ruime
+        keuze aan materialen zoals PLA, PETG en flexibel TPU.
+      </p>
+      <h2 className="mt-8 text-xl font-semibold tracking-tight">Waarom kiezen voor ons?</h2>
+      <ul className="mt-4 list-disc pl-6 text-muted-foreground">
+        <li>Snelle feedback op je STL of STEP-bestanden</li>
+        <li>Consistente kwaliteit dankzij gekalibreerde Bambu Lab-printers</li>
+        <li>Nabewerking en montage op aanvraag</li>
+        <li>Persoonlijk materiaal- en ontwerpadvies</li>
+      </ul>
+      <p className="mt-6 text-muted-foreground">
+        Van een enkel prototype tot een kleine serie: we denken mee vanaf ontwerp tot afgewerkt onderdeel en
+        leveren snel in heel België.
+      </p>
+    </section>
+  );
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -115,6 +115,11 @@ export default function Footer() {
                 </Link>
               </li>
               <li>
+                <Link href="/about" className="hover:text-slate-900">
+                  Over ons
+                </Link>
+              </li>
+              <li>
                 <Link href="/pricing" className="hover:text-slate-900">
                   Prijzen
                 </Link>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -11,6 +11,7 @@ const NAV = [
   { href: "/services", label: "Services" },
   { href: "/materials", label: "Materialen" },
   { href: "/portfolio", label: "Portfolio" },
+  { href: "/about", label: "Over ons" },
   { href: "/pricing", label: "Prijzen" },
   { href: "/contact", label: "Contact" },
 ]


### PR DESCRIPTION
## Wat
- Voeg 'Over ons' pagina toe met SEO-geoptimaliseerde tekst.
- Update navigatie in header en footer.

## Waarom
- Biedt achtergrondinformatie en verbetert interne linkstructuur.

## Testplan
- [x] Build OK (`npm run build`)
- [x] Lint OK (`npm run lint`)
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video
- n.v.t.


------
https://chatgpt.com/codex/tasks/task_b_68acd508eba083329127030137e7e9d7