### PR TITLE
feat: modernize pages with glass elements and global scroll bar

### DIFF
--- a/app/(pages)/about/page.tsx
+++ b/app/(pages)/about/page.tsx
@@ -5,8 +5,8 @@ import Reveal from "@/components/Reveal"
 import Parallax from "@/components/Parallax"
 import TiltCard from "@/components/TiltCard"
 import Counter from "@/components/Counter"
-import ScrollProgress from "@/components/ScrollProgress"
 import GlassOrb from "@/components/GlassOrb"
+import GlassCard from "@/components/GlassCard"
 
 export const metadata: Metadata = {
   title: "Over X3DPrints | 3D-printstudio in Herzele",
@@ -37,8 +37,6 @@ export default function Page() {
 
   return (
     <main className="relative">
-      <ScrollProgress />
-
       {/* Decorative bg */}
       <div
         aria-hidden
@@ -47,11 +45,16 @@ export default function Page() {
       <div aria-hidden className="pointer-events-none absolute inset-0 -z-10 bg-grid-slate-200/[0.06]" />
 
       {/* HERO / INTRO */}
-      <section className="px-6 pt-14 pb-10 sm:px-8 lg:px-12">
+      <section className="relative px-6 pt-14 pb-10 sm:px-8 lg:px-12">
+        <div className="absolute right-0 top-0 -z-10 hidden sm:block">
+          <GlassOrb className="h-64 w-64 opacity-40" />
+        </div>
         <div className="mx-auto max-w-6xl">
           <Reveal className="grid items-center gap-8 sm:grid-cols-[1.3fr_.7fr]">
             <div className="max-w-3xl">
-              <h1 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">Over X3DPrints</h1>
+              <h1 className="bg-gradient-to-br from-slate-900 to-slate-700 bg-clip-text text-3xl font-bold tracking-tight text-transparent sm:text-4xl">
+                Over X3DPrints
+              </h1>
               <p className="mt-3 text-slate-600">
                 X3DPrints is een éénpersoons 3D-printstudio in bijberoep, gevestigd in Herzele en onderdeel van
                 Xinudesign. Je spreekt rechtstreeks met de maker die ook produceert, test en afwerkt. Geen tickets,
@@ -66,19 +69,19 @@ export default function Page() {
               <div className="mt-6 flex flex-wrap gap-3">
                 <Link
                   href="/materials"
-                  className="rounded-xl border border-slate-300/60 bg-white/70 px-4 py-2 text-sm font-semibold text-slate-800 backdrop-blur hover:bg-white"
+                  className="rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-slate-900 backdrop-blur hover:bg-white/20"
                 >
                   Materialen
                 </Link>
                 <Link
                   href="/services"
-                  className="rounded-xl border border-slate-300/60 bg-white/70 px-4 py-2 text-sm font-semibold text-slate-800 backdrop-blur hover:bg-white"
+                  className="rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-slate-900 backdrop-blur hover:bg-white/20"
                 >
                   Diensten
                 </Link>
                 <Link
                   href="/contact"
-                  className="rounded-xl border border-slate-300/60 bg-white/70 px-4 py-2 text-sm font-semibold text-slate-800 backdrop-blur hover:bg-white"
+                  className="rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-slate-900 backdrop-blur hover:bg-white/20"
                 >
                   Contact
                 </Link>
@@ -101,38 +104,38 @@ export default function Page() {
       </section>
 
       {/* STATS / COUNTERS */}
-<section className="px-6 pb-10 sm:px-8 lg:px-12">
-  <div className="mx-auto max-w-6xl">
-    <Reveal className="grid gap-4 sm:grid-cols-3">
-      {/* Bouwvolume */}
-      <div className="rounded-2xl border border-slate-200/70 bg-white/70 p-5 text-center backdrop-blur">
-        <div className="text-xs uppercase tracking-wide text-slate-500">Bouwvolume</div>
-        <div className="mt-1 text-2xl font-semibold text-slate-900">
-          <Counter to={25} suffix=" cm" />
-        </div>
-        <div className="text-xs text-slate-500">per zijde (in één geheel)</div>
-      </div>
+      <section className="px-6 pb-10 sm:px-8 lg:px-12">
+        <div className="mx-auto max-w-6xl">
+          <Reveal className="grid gap-4 sm:grid-cols-3">
+            {/* Bouwvolume */}
+            <GlassCard className="p-5 text-center">
+              <div className="text-xs uppercase tracking-wide text-slate-500">Bouwvolume</div>
+              <div className="mt-1 text-2xl font-semibold text-slate-900">
+                <Counter to={25} suffix=" cm" />
+              </div>
+              <div className="text-xs text-slate-500">per zijde (in één geheel)</div>
+            </GlassCard>
 
-      {/* Doorlooptijd */}
-      <div className="rounded-2xl border border-slate-200/70 bg-white/70 p-5 text-center backdrop-blur">
-        <div className="text-xs uppercase tracking-wide text-slate-500">Doorlooptijd</div>
-        <div className="mt-1 text-2xl font-semibold text-slate-900">
-          <Counter to={5} prefix="2–" suffix=" d" />
-        </div>
-        <div className="text-xs text-slate-500">afhankelijk van project</div>
-      </div>
+            {/* Doorlooptijd */}
+            <GlassCard className="p-5 text-center">
+              <div className="text-xs uppercase tracking-wide text-slate-500">Doorlooptijd</div>
+              <div className="mt-1 text-2xl font-semibold text-slate-900">
+                <Counter to={5} prefix="2–" suffix=" d" />
+              </div>
+              <div className="text-xs text-slate-500">afhankelijk van project</div>
+            </GlassCard>
 
-      {/* Tolerantie */}
-      <div className="rounded-2xl border border-slate-200/70 bg-white/70 p-5 text-center backdrop-blur">
-        <div className="text-xs uppercase tracking-wide text-slate-500">Tolerantie</div>
-        <div className="mt-1 text-2xl font-semibold text-slate-900">
-          <Counter to={0.2} prefix="±" suffix=" mm" decimals={1} locale="nl-BE" />
+            {/* Tolerantie */}
+            <GlassCard className="p-5 text-center">
+              <div className="text-xs uppercase tracking-wide text-slate-500">Tolerantie</div>
+              <div className="mt-1 text-2xl font-semibold text-slate-900">
+                <Counter to={0.2} prefix="±" suffix=" mm" decimals={1} locale="nl-BE" />
+              </div>
+              <div className="text-xs text-slate-500">typisch voor FDM</div>
+            </GlassCard>
+          </Reveal>
         </div>
-        <div className="text-xs text-slate-500">typisch voor FDM</div>
-      </div>
-    </Reveal>
-  </div>
-</section>
+      </section>
 
 
       {/* USP CARDS met 3D tilt */}
@@ -145,9 +148,11 @@ export default function Page() {
               { t: "Afwerking op maat", d: "Rauw, geschuurd, geprimed of gelakt; inserts en montage mogelijk." },
             ].map((u, i) => (
               <Reveal key={u.t} delay={0.05 * (i + 1)}>
-                <TiltCard className="rounded-2xl border border-slate-200/70 bg-white/70 p-6 shadow-sm backdrop-blur">
-                  <h3 className="text-lg font-semibold text-slate-900">{u.t}</h3>
-                  <p className="mt-1 text-slate-600">{u.d}</p>
+                <TiltCard>
+                  <GlassCard className="p-6">
+                    <h3 className="text-lg font-semibold text-slate-900">{u.t}</h3>
+                    <p className="mt-1 text-slate-600">{u.d}</p>
+                  </GlassCard>
                 </TiltCard>
               </Reveal>
             ))}
@@ -159,25 +164,29 @@ export default function Page() {
       <section className="px-6 pb-10 sm:px-8 lg:px-12">
         <div className="mx-auto max-w-6xl">
           <Reveal className="grid gap-8 sm:grid-cols-2">
-            <TiltCard className="rounded-2xl border border-slate-200/70 bg-white/70 p-6 backdrop-blur">
-              <h2 className="text-xl font-semibold tracking-tight text-slate-900">Wat we doen</h2>
-              <ul className="mt-3 list-disc space-y-1 pl-5 text-slate-600">
-                <li>Prototyping en kleine series</li>
-                <li>Winkelmateriaal: displays, houders en POS-oplossingen</li>
-                <li>Gepersonaliseerde items en cadeaus</li>
-                <li>Herstel en maatwerkonderdelen</li>
-              </ul>
+            <TiltCard>
+              <GlassCard className="p-6">
+                <h2 className="text-xl font-semibold tracking-tight text-slate-900">Wat we doen</h2>
+                <ul className="mt-3 list-disc space-y-1 pl-5 text-slate-600">
+                  <li>Prototyping en kleine series</li>
+                  <li>Winkelmateriaal: displays, houders en POS-oplossingen</li>
+                  <li>Gepersonaliseerde items en cadeaus</li>
+                  <li>Herstel en maatwerkonderdelen</li>
+                </ul>
+              </GlassCard>
             </TiltCard>
 
-            <TiltCard className="rounded-2xl border border-slate-200/70 bg-white/70 p-6 backdrop-blur">
-              <h2 className="text-xl font-semibold tracking-tight text-slate-900">Hoe we werken</h2>
-              <ol className="mt-3 list-decimal space-y-1 pl-5 text-slate-600">
-                <li>Upload je STL/STEP met toepassing en gewenste afwerking</li>
-                <li>Eerlijk materiaaladvies en transparante offerte</li>
-                <li>Productie, kwaliteitscheck en eventuele nabewerking</li>
-                <li>Verzending in BE of afhalen in regio Herzele/Gent</li>
-              </ol>
-              <p className="mt-3 text-sm text-slate-500">Levertijd meestal 2–5 werkdagen; spoed in overleg.</p>
+            <TiltCard>
+              <GlassCard className="p-6">
+                <h2 className="text-xl font-semibold tracking-tight text-slate-900">Hoe we werken</h2>
+                <ol className="mt-3 list-decimal space-y-1 pl-5 text-slate-600">
+                  <li>Upload je STL/STEP met toepassing en gewenste afwerking</li>
+                  <li>Eerlijk materiaaladvies en transparante offerte</li>
+                  <li>Productie, kwaliteitscheck en eventuele nabewerking</li>
+                  <li>Verzending in BE of afhalen in regio Herzele/Gent</li>
+                </ol>
+                <p className="mt-3 text-sm text-slate-500">Levertijd meestal 2–5 werkdagen; spoed in overleg.</p>
+              </GlassCard>
             </TiltCard>
           </Reveal>
         </div>
@@ -186,42 +195,44 @@ export default function Page() {
       {/* MATERIALEN & SPECIFICS */}
       <section className="px-6 pb-12 sm:px-8 lg:px-12">
         <div className="mx-auto max-w-6xl">
-          <Reveal className="rounded-2xl border border-slate-200/70 bg-white/70 p-6 backdrop-blur">
-            <h2 className="text-xl font-semibold tracking-tight text-slate-900">Materialen & specificaties</h2>
-            <div className="mt-3 grid gap-6 sm:grid-cols-2">
-              <div>
-                <h3 className="text-sm font-semibold text-slate-900">Materialen</h3>
-                <ul className="mt-2 list-disc space-y-1 pl-5 text-slate-600">
-                  <li>PLA (standaard, veel kleuren en varianten)</li>
-                  <li>PETG (sterker, vocht- en chemie-resistenter)</li>
-                  <li>ABS / ASA (hitte- en UV-bestendig)</li>
-                  <li>Nylon (PA) en PA-CF (stijf/sterk; jigs/fixtures)</li>
-                  <li>TPU (flexibel) op aanvraag</li>
-                </ul>
+          <Reveal>
+            <GlassCard className="p-6">
+              <h2 className="text-xl font-semibold tracking-tight text-slate-900">Materialen & specificaties</h2>
+              <div className="mt-3 grid gap-6 sm:grid-cols-2">
+                <div>
+                  <h3 className="text-sm font-semibold text-slate-900">Materialen</h3>
+                  <ul className="mt-2 list-disc space-y-1 pl-5 text-slate-600">
+                    <li>PLA (standaard, veel kleuren en varianten)</li>
+                    <li>PETG (sterker, vocht- en chemie-resistenter)</li>
+                    <li>ABS / ASA (hitte- en UV-bestendig)</li>
+                    <li>Nylon (PA) en PA-CF (stijf/sterk; jigs/fixtures)</li>
+                    <li>TPU (flexibel) op aanvraag</li>
+                  </ul>
+                </div>
+                <div>
+                  <h3 className="text-sm font-semibold text-slate-900">Specs</h3>
+                  <ul className="mt-2 list-disc space-y-1 pl-5 text-slate-600">
+                    <li>Bouwvolume tot 25 × 25 × 25 cm per stuk</li>
+                    <li>Layerhoogte 0,12–0,28 mm</li>
+                    <li>Afwerking</li>
+                  </ul>
+                </div>
               </div>
-              <div>
-                <h3 className="text-sm font-semibold text-slate-900">Specs</h3>
-                <ul className="mt-2 list-disc space-y-1 pl-5 text-slate-600">
-                  <li>Bouwvolume tot 25 × 25 × 25 cm per stuk</li>
-                  <li>Layerhoogte 0,12–0,28 mm</li>
-                  <li>Afwerking</li>
-                </ul>
+              <div className="mt-5 flex flex-wrap gap-3">
+                <Link
+                  href="/materials"
+                  className="rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-slate-900 backdrop-blur hover:bg-white/20"
+                >
+                  Alle materialen
+                </Link>
+                <Link
+                  href="/pricing"
+                  className="rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-slate-900 backdrop-blur hover:bg-white/20"
+                >
+                  Prijzen & levering
+                </Link>
               </div>
-            </div>
-            <div className="mt-5 flex flex-wrap gap-3">
-              <Link
-                href="/materials"
-                className="rounded-xl border border-slate-300/60 bg-white/70 px-4 py-2 text-sm font-semibold text-slate-800 hover:bg-white"
-              >
-                Alle materialen
-              </Link>
-              <Link
-                href="/pricing"
-                className="rounded-xl border border-slate-300/60 bg-white/70 px-4 py-2 text-sm font-semibold text-slate-800 hover:bg-white"
-              >
-                Prijzen & levering
-              </Link>
-            </div>
+            </GlassCard>
           </Reveal>
         </div>
       </section>
@@ -229,34 +240,36 @@ export default function Page() {
       {/* CTA */}
       <section className="px-6 pb-20 sm:px-8 lg:px-12">
         <div className="mx-auto max-w-6xl">
-          <Reveal className="overflow-hidden rounded-3xl border border-slate-200/70 bg-white/70 p-8 backdrop-blur sm:p-10">
-            <div className="grid gap-6 sm:grid-cols-[1.2fr_.8fr] sm:items-center">
-              <div>
-                <h2 className="text-2xl font-bold tracking-tight text-slate-900 sm:text-3xl">Samen iets moois maken?</h2>
-                <p className="mt-2 max-w-prose text-slate-600">
-                  Stuur je model door en ontvang snel een heldere prijs met het beste materiaaladvies voor jouw toepassing.
-                </p>
-                <div className="mt-5 flex flex-wrap gap-3">
-                  <Link
-                    href="/contact"
-                    className="rounded-xl border border-slate-300/60 bg-black px-5 py-3 text-sm font-semibold text-white hover:brightness-110"
-                  >
-                    Offerte aanvragen
-                  </Link>
-                  <Link
-                    href="/portfolio"
-                    className="rounded-xl border border-slate-300/60 bg-white/70 px-5 py-3 text-sm font-semibold text-slate-800"
-                  >
-                    Portfolio
-                  </Link>
+          <Reveal>
+            <GlassCard className="overflow-hidden p-8 sm:p-10">
+              <div className="grid gap-6 sm:grid-cols-[1.2fr_.8fr] sm:items-center">
+                <div>
+                  <h2 className="text-2xl font-bold tracking-tight text-slate-900 sm:text-3xl">Samen iets moois maken?</h2>
+                  <p className="mt-2 max-w-prose text-slate-600">
+                    Stuur je model door en ontvang snel een heldere prijs met het beste materiaaladvies voor jouw toepassing.
+                  </p>
+                  <div className="mt-5 flex flex-wrap gap-3">
+                    <Link
+                      href="/contact"
+                      className="rounded-xl border border-white/20 bg-black px-5 py-3 text-sm font-semibold text-white hover:brightness-110"
+                    >
+                      Offerte aanvragen
+                    </Link>
+                    <Link
+                      href="/portfolio"
+                      className="rounded-xl border border-white/20 bg-white/10 px-5 py-3 text-sm font-semibold text-slate-900 backdrop-blur hover:bg-white/20"
+                    >
+                      Portfolio
+                    </Link>
+                  </div>
                 </div>
+                <Parallax offset={18} className="justify-self-end">
+                  <div className="justify-self-end">
+                    <GlassOrb className="h-40 w-40 opacity-90" />
+                  </div>
+                </Parallax>
               </div>
-              <Parallax offset={18} className="justify-self-end">
-                <div className="justify-self-end">
-  <GlassOrb className="h-40 w-40 opacity-90" />
-</div>
-              </Parallax>
-            </div>
+            </GlassCard>
           </Reveal>
         </div>
       </section>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,8 +3,8 @@ import type { Metadata } from "next"
 import { SITE } from "@/lib/seo"
 import Header from "@/components/Header"
 import Footer from "@/components/Footer"
+import ScrollProgress from "@/components/ScrollProgress"
 import { cn } from "@/lib/utils";
-
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE.url),
@@ -62,12 +62,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="nl">
       <body className={cn("min-h-screen flex flex-col")}>
+        <ScrollProgress />
         <Header />
         <main className="flex-1">{children}</main>
         <Footer />
         <script
           type="application/ld+json"
-          
           dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
         />
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import Reveal from "@/components/Reveal"
 import ShimmerButton from "@/components/ShimmerButton"
 import Catchphrase from "@/components/Catchphrase"
 import GlassOrb from "@/components/GlassOrb"
+import GlassCard from "@/components/GlassCard"
 
 export const metadata: Metadata = {
   title: "3D print service in Herzele | X3DPrints",
@@ -78,22 +79,25 @@ export default function HomePage() {
       <div aria-hidden className="pointer-events-none absolute inset-0 -z-10 bg-grid-slate-200/[0.07]" />
 
       {/* HERO */}
-      <section className="px-6 pb-24 pt-20 sm:px-8 lg:px-12 lg:pb-32 lg:pt-28">
+      <section className="relative px-6 pb-24 pt-20 sm:px-8 lg:px-12 lg:pb-32 lg:pt-28">
+        <div className="absolute right-0 top-0 -z-10 hidden sm:block">
+          <GlassOrb className="h-72 w-72 opacity-40" />
+        </div>
         <div className="mx-auto max-w-6xl">
           <Reveal className="max-w-3xl">
-            <span className="mb-4 inline-flex items-center gap-2 rounded-full border border-slate-200/40 bg-white/60 px-3 py-1 text-xs text-slate-700 backdrop-blur">
+            <span className="mb-4 inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs text-slate-700 backdrop-blur">
               <span className="h-2 w-2 rounded-full bg-emerald-400" />
               Snel, precies en betaalbaar
             </span>
             <Catchphrase className="mt-4 block text-base font-medium text-indigo-600 sm:text-lg">
-               Betaalbaar 3D printen
+              Betaalbaar 3D printen
             </Catchphrase>
-            <h1 className="mt-2 text-balance text-4xl font-extrabold leading-tight tracking-tight text-slate-900 sm:text-5xl">
-              3D-prints die wél kloppen.{" "}
-              <span className="bg-gradient-to-r from-indigo-600 via-sky-400 to-emerald-400 bg-clip-text text-transparent">
-                Where design meets dimension.
-              </span>
+            <h1 className="mt-2 bg-gradient-to-br from-slate-900 to-slate-700 bg-clip-text text-balance text-4xl font-extrabold leading-tight tracking-tight text-transparent sm:text-5xl">
+              3D-prints die wél kloppen.
             </h1>
+            <p className="mt-2 text-balance text-lg font-medium text-slate-700">
+              Where design meets dimension.
+            </p>
             <p className="mt-5 max-w-2xl text-pretty text-base leading-7 text-slate-600 sm:text-lg">
               X3DPrints is een compacte 3D-printstudio uit Herzele, onderdeel van Xinudesign. Ideaal voor prototypes en
               kleine series met strakke afwerking. PLA is onze standaard, maar we schakelen waar nodig over naar PETG,
@@ -103,7 +107,7 @@ export default function HomePage() {
               <ShimmerButton href="/contact">Offerte aanvragen</ShimmerButton>
               <Link
                 href="/portfolio"
-                className="inline-flex items-center gap-2 rounded-xl border border-slate-300/60 bg-white/70 px-5 py-3 text-sm font-semibold text-slate-800 backdrop-blur transition-transform hover:-translate-y-0.5 hover:bg-white"
+                className="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-5 py-3 text-sm font-semibold text-slate-900 backdrop-blur transition-transform hover:-translate-y-0.5 hover:bg-white/20"
               >
                 Bekijk portfolio
               </Link>
@@ -141,14 +145,14 @@ export default function HomePage() {
                 ),
               },
             ].map((item) => (
-              <div
+              <GlassCard
                 key={item.k}
-                className="rounded-2xl border border-slate-200/70 bg-white/70 p-5 text-slate-800 backdrop-blur transition-transform hover:-translate-y-1 hover:shadow-lg"
+                className="p-5 text-center transition-transform hover:-translate-y-1"
               >
                 {item.icon}
                 <div className="text-sm text-slate-500">{item.k}</div>
-                <div className="mt-1 text-xl font-semibold">{item.v}</div>
-              </div>
+                <div className="mt-1 text-xl font-semibold text-slate-900">{item.v}</div>
+              </GlassCard>
             ))}
           </Reveal>
         </div>
@@ -171,13 +175,13 @@ export default function HomePage() {
               <div className="mt-6 flex gap-3">
                 <Link
                   href="/services"
-                  className="rounded-xl border border-slate-300/60 bg-white/70 px-5 py-3 text-sm font-semibold text-slate-800 transition-transform hover:-translate-y-0.5"
+                  className="rounded-xl border border-white/20 bg-white/10 px-5 py-3 text-sm font-semibold text-slate-900 backdrop-blur transition-transform hover:-translate-y-0.5 hover:bg-white/20"
                 >
                   Diensten
                 </Link>
                 <Link
                   href="/materials"
-                  className="rounded-xl border border-slate-300/60 bg-white/70 px-5 py-3 text-sm font-semibold text-slate-800 transition-transform hover:-translate-y-0.5"
+                  className="rounded-xl border border-white/20 bg-white/10 px-5 py-3 text-sm font-semibold text-slate-900 backdrop-blur transition-transform hover:-translate-y-0.5 hover:bg-white/20"
                 >
                   Materialen
                 </Link>
@@ -200,7 +204,7 @@ export default function HomePage() {
             </p>
           </Reveal>
           <div className="grid gap-6 sm:grid-cols-2">
-            <div className="rounded-2xl border border-slate-200/70 bg-white/70 p-6 transition-transform hover:-translate-y-1 hover:shadow-lg">
+            <GlassCard className="p-6 transition-transform hover:-translate-y-1">
               {icon(<circle cx={12} cy={12} r={9} />)}
               <h3 className="text-lg font-semibold text-slate-900">Particulieren</h3>
               <ul className="mt-2 list-disc space-y-1 pl-5 text-slate-600">
@@ -208,8 +212,8 @@ export default function HomePage() {
                 <li>Decor & design: vazen, lampenkappen, interieurstukken</li>
                 <li>Unieke accessoires en mini-sculpturen</li>
               </ul>
-            </div>
-            <div className="rounded-2xl border border-slate-200/70 bg-white/70 p-6 transition-transform hover:-translate-y-1 hover:shadow-lg">
+            </GlassCard>
+            <GlassCard className="p-6 transition-transform hover:-translate-y-1">
               {icon(<rect x={4} y={4} width={16} height={16} rx={2} />)}
               <h3 className="text-lg font-semibold text-slate-900">Bedrijven</h3>
               <ul className="mt-2 list-disc space-y-1 pl-5 text-slate-600">
@@ -217,12 +221,12 @@ export default function HomePage() {
                 <li>Bedrijfscadeaus en promotieartikelen</li>
                 <li>Prototyping, jigs, fixtures en kleine series</li>
               </ul>
-            </div>
+            </GlassCard>
           </div>
           <div className="mt-8">
             <Link
               href="/portfolio"
-              className="inline-flex items-center rounded-xl border border-slate-300/60 bg-white/70 px-4 py-2 text-sm font-semibold text-slate-800 transition-transform hover:-translate-y-0.5"
+              className="inline-flex items-center rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-slate-900 backdrop-blur transition-transform hover:-translate-y-0.5 hover:bg-white/20"
             >
               Gallerij bekijken
             </Link>
@@ -258,14 +262,12 @@ export default function HomePage() {
                 icon: icon(<path strokeLinecap="round" strokeLinejoin="round" d="M4 4h16v16H4z" />),
               },
             ].map((s, i) => (
-              <Reveal
-                key={s.t}
-                delay={0.05 * (i + 1)}
-                className="rounded-xl border border-slate-200/70 bg-white/70 p-5 transition-transform hover:-translate-y-1 hover:shadow-lg"
-              >
-                {s.icon}
-                <div className="text-base font-semibold text-slate-900">{s.t}</div>
-                <div className="mt-1 text-sm text-slate-600">{s.d}</div>
+              <Reveal key={s.t} delay={0.05 * (i + 1)}>
+                <GlassCard className="p-5 transition-transform hover:-translate-y-1">
+                  {s.icon}
+                  <div className="text-base font-semibold text-slate-900">{s.t}</div>
+                  <div className="mt-1 text-sm text-slate-600">{s.d}</div>
+                </GlassCard>
               </Reveal>
             ))}
           </div>
@@ -291,14 +293,12 @@ export default function HomePage() {
               { n: "PA-CF", u: "Nylon met carbon; stijf en licht voor jigs/fixtures.", icon: icon(<path strokeLinecap="round" strokeLinejoin="round" d="M4 4h16v16H4z M4 4l16 16" />) },
               { n: "Specials", u: "TPU, vlamvertragend of glas-gevuld op aanvraag.", icon: icon(<path strokeLinecap="round" strokeLinejoin="round" d="M12 3l8 6v6l-8 6-8-6V9l8-6z" />) },
             ].map((m, i) => (
-              <Reveal
-                key={m.n}
-                delay={0.05 * (i + 1)}
-                className="rounded-xl border border-slate-200/70 bg-white/70 p-5 transition-transform hover:-translate-y-1 hover:shadow-lg"
-              >
-                {m.icon}
-                <div className="text-base font-semibold text-slate-900">{m.n}</div>
-                <div className="mt-1 text-sm text-slate-600">{m.u}</div>
+              <Reveal key={m.n} delay={0.05 * (i + 1)}>
+                <GlassCard className="p-5 transition-transform hover:-translate-y-1">
+                  {m.icon}
+                  <div className="text-base font-semibold text-slate-900">{m.n}</div>
+                  <div className="mt-1 text-sm text-slate-600">{m.u}</div>
+                </GlassCard>
               </Reveal>
             ))}
           </div>
@@ -343,14 +343,12 @@ export default function HomePage() {
                 icon: icon(<path strokeLinecap="round" strokeLinejoin="round" d="M8 14s2 2 4 2 4-2 4-2" />),
               },
             ].map((s, i) => (
-              <Reveal
-                key={s.t}
-                delay={0.05 * (i + 1)}
-                className="rounded-2xl border border-slate-200/70 bg-white/70 p-6 transition-transform hover:-translate-y-1 hover:shadow-lg"
-              >
-                {s.icon}
-                <div className="text-base font-semibold text-slate-900">{s.t}</div>
-                <div className="mt-1 text-sm text-slate-600">{s.d}</div>
+              <Reveal key={s.t} delay={0.05 * (i + 1)}>
+                <GlassCard className="p-6 transition-transform hover:-translate-y-1">
+                  {s.icon}
+                  <div className="text-base font-semibold text-slate-900">{s.t}</div>
+                  <div className="mt-1 text-sm text-slate-600">{s.d}</div>
+                </GlassCard>
               </Reveal>
             ))}
           </div>
@@ -389,21 +387,19 @@ export default function HomePage() {
                 icon: icon(<path strokeLinecap="round" strokeLinejoin="round" d="M4 12h16M14 8l6 4-6 4" />),
               },
             ].map((s, i) => (
-              <Reveal
-                key={s.t}
-                delay={0.05 * (i + 1)}
-                className="rounded-2xl border border-slate-200/70 bg-white/70 p-6 transition-transform hover:-translate-y-1 hover:shadow-lg"
-              >
-                {s.icon}
-                <div className="text-base font-semibold text-slate-900">{s.t}</div>
-                <div className="mt-1 text-sm text-slate-600">{s.d}</div>
+              <Reveal key={s.t} delay={0.05 * (i + 1)}>
+                <GlassCard className="p-6 transition-transform hover:-translate-y-1">
+                  {s.icon}
+                  <div className="text-base font-semibold text-slate-900">{s.t}</div>
+                  <div className="mt-1 text-sm text-slate-600">{s.d}</div>
+                </GlassCard>
               </Reveal>
             ))}
           </div>
           <div className="mt-10 flex gap-3">
             <Link
               href="/pricing"
-              className="rounded-xl border border-slate-300/60 bg-white/70 px-4 py-2 text-sm font-semibold text-slate-800 transition-transform hover:-translate-y-0.5"
+              className="rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-slate-900 backdrop-blur transition-transform hover:-translate-y-0.5 hover:bg-white/20"
             >
               Prijzen bekijken
             </Link>
@@ -415,32 +411,32 @@ export default function HomePage() {
       {/* CTA */}
       <section className="px-6 pb-32 pt-10 sm:px-8 lg:px-12">
         <div className="mx-auto max-w-6xl">
-          <Reveal className="overflow-hidden rounded-3xl border border-slate-200/70 bg-white/70 p-8 backdrop-blur sm:p-10">
-            <div className="grid gap-6 sm:grid-cols-[1.2fr_.8fr] sm:items-center">
-              <div>
-                <h2 className="text-balance text-2xl font-bold tracking-tight text-slate-900 sm:text-3xl">
-                  Klaar om te printen?
-                </h2>
-                <p className="mt-2 max-w-prose text-slate-600">
-                  Stuur je model door en je krijgt snel een heldere prijs met het beste materiaaladvies voor jouw
-                  toepassing.
-                </p>
-                <div className="mt-8 flex flex-wrap gap-3">
-                  <ShimmerButton href="/contact">Offerte aanvragen</ShimmerButton>
-                  <Link
-                    href="/portfolio"
-                    className="inline-flex items-center gap-2 rounded-xl border border-slate-300/60 bg-white/70 px-5 py-3 text-sm font-semibold text-slate-800 transition-transform hover:-translate-y-0.5"
-                  >
-                    Gallerij bekijken
-                  </Link>
+          <Reveal>
+            <GlassCard className="overflow-hidden p-8 sm:p-10">
+              <div className="grid gap-6 sm:grid-cols-[1.2fr_.8fr] sm:items-center">
+                <div>
+                  <h2 className="text-balance text-2xl font-bold tracking-tight text-slate-900 sm:text-3xl">
+                    Klaar om te printen?
+                  </h2>
+                  <p className="mt-2 max-w-prose text-slate-600">
+                    Stuur je model door en je krijgt snel een heldere prijs met het beste materiaaladvies voor jouw
+                    toepassing.
+                  </p>
+                  <div className="mt-8 flex flex-wrap gap-3">
+                    <ShimmerButton href="/contact">Offerte aanvragen</ShimmerButton>
+                    <Link
+                      href="/portfolio"
+                      className="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-5 py-3 text-sm font-semibold text-slate-900 backdrop-blur transition-transform hover:-translate-y-0.5 hover:bg-white/20"
+                    >
+                      Gallerij bekijken
+                    </Link>
+                  </div>
+                </div>
+                <div className="justify-self-end">
+                  <GlassOrb className="h-40 w-40 opacity-90" />
                 </div>
               </div>
-              <div className="justify-self-end">
-                <div className="justify-self-end">
-  <GlassOrb className="h-40 w-40 opacity-90" />
-</div>
-              </div>
-            </div>
+            </GlassCard>
           </Reveal>
         </div>
       </section>

--- a/components/GlassCard.tsx
+++ b/components/GlassCard.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react"
+import { cn } from "@/lib/utils"
+
+export default function GlassCard({ children, className = "" }: { children: ReactNode; className?: string }) {
+  return (
+    <div
+      className={cn(
+        "rounded-3xl border border-white/20 bg-white/10 p-6 shadow-lg backdrop-blur-xl",
+        className
+      )}
+    >
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
## Wat
- Modernized home page with glassmorphism: gradient hero, translucent buttons, glass stat and content cards
- Reused `GlassCard` across segments, materialen, PLA, pricing and CTA for Tesla‑like 2025 look
- Added global ScrollProgress bar so the top indicator shows on every page

## Waarom
- Zorgt voor consistente futuristische UX en scrollfeedback op elke pagina

## Testplan
- [x] Build OK (`npm run build`)
- [x] Lint OK (`npm run lint`)
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Metadata/OG/JSON-LD up-to-date
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video


------
https://chatgpt.com/codex/tasks/task_b_68ad573775b48332ace0b3d0b5f04128