### PR TITLE
feat: add animated materials overview

### DIFF
--- a/app/(pages)/materials/page.tsx
+++ b/app/(pages)/materials/page.tsx
@@ -1,17 +1,76 @@
-import type { Metadata } from "next";
+import type { Metadata } from "next"
+
+import Container from "@/components/Container"
+import MaterialCard from "@/components/MaterialCard"
+import Reveal from "@/components/Reveal"
+import ShimmerButton from "@/components/ShimmerButton"
+
+const materials = [
+  {
+    title: "PLA",
+    description: "Betaalbaar bioplastic voor prototypes en decoratieve prints.",
+    features: [
+      "Scherpe details",
+      "Milieuvriendelijk",
+      "Snelle levertijd",
+    ],
+  },
+  {
+    title: "PETG",
+    description: "Sterk en licht flexibel voor functionele onderdelen.",
+    features: [
+      "Hoge slagvastheid",
+      "Temperatuurbestendig",
+      "Glad oppervlak",
+    ],
+  },
+  {
+    title: "ABS",
+    description: "Robuust materiaal voor technische toepassingen en outdoor gebruik.",
+    features: [
+      "Hittebestendig",
+      "Nabewerking mogelijk",
+      "Professionele kwaliteit",
+    ],
+  },
+  {
+    title: "Resin",
+    description: "Ultieme precisie voor miniaturen en productiemodellen.",
+    features: [
+      "Haarscherpe details",
+      "Glad als gegoten",
+      "Perfect voor masters",
+    ],
+  },
+] as const
 
 export const metadata: Metadata = {
   title: "Materialen",
-  description: "Overzicht van beschikbare 3D-print materialen en richtlijnen.",
-};
+  description: "Ontdek PLA, PETG, ABS en Resin voor jouw 3D-print project.",
+}
 
 export default function Page() {
   return (
-    <section className="container mx-auto max-w-3xl py-12">
+    <Container className="py-12">
       <h1 className="text-3xl font-semibold tracking-tight">Materialen</h1>
-      <p className="mt-4 text-muted-foreground">
-        Placeholder. Hier komt later jouw materiaaloverzicht met eigenschappen en toepassingen.
+      <p className="mt-4 max-w-2xl text-muted-foreground">
+        Elk project vraagt om het juiste materiaal. Kies uit onze meest gebruikte opties
+        en profiteer van persoonlijk advies voor jouw toepassing.
       </p>
-    </section>
-  );
+      <div className="mt-10 grid gap-6 sm:grid-cols-2">
+        {materials.map((material, index) => (
+          <MaterialCard key={material.title} {...material} delay={index * 0.1} />
+        ))}
+      </div>
+      <Reveal delay={0.4} className="mt-16 text-center">
+        <p className="text-muted-foreground">
+          Twijfel je over de beste keuze? We denken graag met je mee.
+        </p>
+        <div className="mt-4 flex justify-center">
+          <ShimmerButton href="/contact">Vraag persoonlijk advies</ShimmerButton>
+        </div>
+      </Reveal>
+    </Container>
+  )
 }
+

--- a/components/MaterialCard.tsx
+++ b/components/MaterialCard.tsx
@@ -1,0 +1,41 @@
+"use client"
+
+import Reveal from "./Reveal"
+import GlassCard from "./GlassCard"
+import ShimmerButton from "./ShimmerButton"
+
+export type MaterialCardProps = {
+  title: string
+  description: string
+  features: readonly string[]
+  delay?: number
+}
+
+export default function MaterialCard({
+  title,
+  description,
+  features,
+  delay = 0,
+}: MaterialCardProps) {
+  return (
+    <Reveal delay={delay} className="h-full">
+      <GlassCard className="flex h-full flex-col justify-between">
+        <div>
+          <h3 className="text-xl font-semibold leading-tight">{title}</h3>
+          <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+          <ul className="mt-4 list-disc space-y-1 pl-4 text-sm">
+            {features.map((feature) => (
+              <li key={feature}>{feature}</li>
+            ))}
+          </ul>
+        </div>
+        <div className="mt-6">
+          <ShimmerButton href="/contact" className="w-full justify-center">
+            Vraag offerte
+          </ShimmerButton>
+        </div>
+      </GlassCard>
+    </Reveal>
+  )
+}
+


### PR DESCRIPTION
## Wat
- toon verkoopgerichte materiaaloverzicht met animaties
- voeg herbruikbare `MaterialCard` component toe

## Waarom
- geeft klanten inzicht in materiaalkeuze en stimuleert contact

## Testplan
- [x] Build OK
- [x] Lint OK
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video



------
https://chatgpt.com/codex/tasks/task_b_68ad66dd1558833292ba32cdf4514aee