### PR TITLE
feat: add contact form with PHP mailer and honeypot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# php
+/php/vendor

--- a/app/(pages)/contact/page.tsx
+++ b/app/(pages)/contact/page.tsx
@@ -2,9 +2,39 @@
 
 import { useState } from "react";
 
+type FormData = {
+  name: string;
+  email: string;
+  message: string;
+  type: "private" | "business";
+  company: string;
+  vat: string;
+  address: string;
+  quantity: string;
+  material: string;
+  hp: string; // honeypot
+};
+
 export default function ContactForm() {
-  const [data, setData] = useState({ name: "", email: "", message: "" });
-  const [status, setStatus] = useState<"idle" | "loading" | "ok" | "error">("idle");
+  const [data, setData] = useState<FormData>({
+    name: "",
+    email: "",
+    message: "",
+    type: "private",
+    company: "",
+    vat: "",
+    address: "",
+    quantity: "",
+    material: "",
+    hp: "",
+  });
+  const [status, setStatus] = useState<"idle" | "loading" | "ok" | "error">(
+    "idle",
+  );
+
+  function update<K extends keyof FormData>(key: K, value: FormData[K]) {
+    setData({ ...data, [key]: value });
+  }
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -27,7 +57,7 @@ export default function ContactForm() {
         className="border rounded p-2"
         placeholder="Naam"
         value={data.name}
-        onChange={(e) => setData({ ...data, name: e.target.value })}
+        onChange={(e) => update("name", e.target.value)}
         required
       />
       <input
@@ -35,16 +65,69 @@ export default function ContactForm() {
         type="email"
         placeholder="E-mail"
         value={data.email}
-        onChange={(e) => setData({ ...data, email: e.target.value })}
+        onChange={(e) => update("email", e.target.value)}
         required
+      />
+      <select
+        className="border rounded p-2"
+        value={data.type}
+        onChange={(e) => update("type", e.target.value as FormData["type"])}
+      >
+        <option value="private">Particulier</option>
+        <option value="business">Bedrijf</option>
+      </select>
+      {data.type === "business" ? (
+        <>
+          <input
+            className="border rounded p-2"
+            placeholder="Bedrijfsnaam"
+            value={data.company}
+            onChange={(e) => update("company", e.target.value)}
+            required
+          />
+          <input
+            className="border rounded p-2"
+            placeholder="BTW-nummer"
+            value={data.vat}
+            onChange={(e) => update("vat", e.target.value)}
+          />
+        </>
+      ) : (
+        <input
+          className="border rounded p-2"
+          placeholder="Adres"
+          value={data.address}
+          onChange={(e) => update("address", e.target.value)}
+        />
+      )}
+      <input
+        className="border rounded p-2"
+        type="number"
+        placeholder="Aantal"
+        value={data.quantity}
+        onChange={(e) => update("quantity", e.target.value)}
+      />
+      <input
+        className="border rounded p-2"
+        placeholder="Materiaal"
+        value={data.material}
+        onChange={(e) => update("material", e.target.value)}
       />
       <textarea
         className="border rounded p-2"
         placeholder="Bericht"
         rows={5}
         value={data.message}
-        onChange={(e) => setData({ ...data, message: e.target.value })}
+        onChange={(e) => update("message", e.target.value)}
         required
+      />
+      {/* honeypot */}
+      <input
+        tabIndex={-1}
+        autoComplete="off"
+        className="hidden"
+        value={data.hp}
+        onChange={(e) => update("hp", e.target.value)}
       />
       <button
         type="submit"

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,5 +1,23 @@
-// /app/api/contact/route.ts
 import { NextResponse } from "next/server";
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+interface FormData {
+  name: string;
+  email: string;
+  message: string;
+  type: "private" | "business";
+  company?: string;
+  vat?: string;
+  address?: string;
+  quantity?: string;
+  material?: string;
+  hp?: string;
+}
+
+function isEmail(email: string) {
+  return /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email);
+}
 
 export async function POST(req: Request) {
   let payload: unknown;
@@ -9,18 +27,38 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  const data = payload as {
-    name?: string;
-    email?: string;
-    message?: string;
-  };
+  const data = payload as FormData;
 
-  if (!data?.name || !data?.email || !data?.message) {
+  if (data.hp) {
+    // honeypot triggered
+    return NextResponse.json({ ok: true });
+  }
+
+  if (!data.name || !isEmail(data.email) || !data.message) {
     return NextResponse.json({ error: "Missing fields" }, { status: 422 });
   }
 
-  // TODO: stuur mail, sla op, whatever
-  // await sendMail(data)
+  try {
+    await sendWithPhpMailer(data);
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ error: "Mail failed" }, { status: 500 });
+  }
+}
 
-  return NextResponse.json({ ok: true });
+function sendWithPhpMailer(data: FormData) {
+  const script = path.join(process.cwd(), "php", "mail.php");
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn("php", [script]);
+    child.stdin.write(JSON.stringify(data));
+    child.stdin.end();
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error("php failed"));
+      }
+    });
+    child.on("error", reject);
+  });
 }

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "phpmailer/phpmailer": "^6.10"
+    }
+}

--- a/php/composer.lock
+++ b/php/composer.lock
@@ -1,0 +1,100 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "cb5da62d73716ac8a1776f19367bc28f",
+    "packages": [
+        {
+            "name": "phpmailer/phpmailer",
+            "version": "v6.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPMailer/PHPMailer.git",
+                "reference": "bf74d75a1fde6beaa34a0ddae2ec5fce0f72a144"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/bf74d75a1fde6beaa34a0ddae2ec5fce0f72a144",
+                "reference": "bf74d75a1fde6beaa34a0ddae2ec5fce0f72a144",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-filter": "*",
+                "ext-hash": "*",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "doctrine/annotations": "^1.2.6 || ^1.13.3",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcompatibility/php-compatibility": "^9.3.5",
+                "roave/security-advisories": "dev-latest",
+                "squizlabs/php_codesniffer": "^3.7.2",
+                "yoast/phpunit-polyfills": "^1.0.4"
+            },
+            "suggest": {
+                "decomplexity/SendOauth2": "Adapter for using XOAUTH2 authentication",
+                "ext-mbstring": "Needed to send email in multibyte encoding charset or decode encoded addresses",
+                "ext-openssl": "Needed for secure SMTP sending and DKIM signing",
+                "greew/oauth2-azure-provider": "Needed for Microsoft Azure XOAUTH2 authentication",
+                "hayageek/oauth2-yahoo": "Needed for Yahoo XOAUTH2 authentication",
+                "league/oauth2-google": "Needed for Google XOAUTH2 authentication",
+                "psr/log": "For optional PSR-3 debug logging",
+                "symfony/polyfill-mbstring": "To support UTF-8 if the Mbstring PHP extension is not enabled (^1.2)",
+                "thenetworg/oauth2-azure": "Needed for Microsoft XOAUTH2 authentication"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPMailer\\PHPMailer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-only"
+            ],
+            "authors": [
+                {
+                    "name": "Marcus Bointon",
+                    "email": "phpmailer@synchromedia.co.uk"
+                },
+                {
+                    "name": "Jim Jagielski",
+                    "email": "jimjag@gmail.com"
+                },
+                {
+                    "name": "Andy Prevost",
+                    "email": "codeworxtech@users.sourceforge.net"
+                },
+                {
+                    "name": "Brent R. Matzelle"
+                }
+            ],
+            "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
+            "support": {
+                "issues": "https://github.com/PHPMailer/PHPMailer/issues",
+                "source": "https://github.com/PHPMailer/PHPMailer/tree/v6.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Synchro",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-04-24T15:19:31+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/php/mail.php
+++ b/php/mail.php
@@ -1,0 +1,39 @@
+<?php
+require __DIR__ . '/vendor/autoload.php';
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception;
+
+$input = stream_get_contents(STDIN);
+$data = json_decode($input, true);
+if (!is_array($data)) {
+    fwrite(STDERR, "Invalid input\n");
+    exit(1);
+}
+
+$mail = new PHPMailer(true);
+try {
+    // Configure basic mail settings (adjust as needed)
+    $mail->setFrom($data['email'] ?? '', $data['name'] ?? '');
+    $mail->addAddress('info@example.com'); // TODO: change to actual recipient
+    $mail->Subject = 'Nieuw bericht via contactformulier';
+
+    $body = "Naam: " . ($data['name'] ?? '') . "\n";
+    $body .= "Email: " . ($data['email'] ?? '') . "\n";
+    $body .= "Type: " . ($data['type'] ?? '') . "\n";
+    if (($data['type'] ?? '') === 'business') {
+        $body .= "Bedrijfsnaam: " . ($data['company'] ?? '') . "\n";
+        $body .= "BTW-nummer: " . ($data['vat'] ?? '') . "\n";
+    } else {
+        $body .= "Adres: " . ($data['address'] ?? '') . "\n";
+    }
+    $body .= "Aantal: " . ($data['quantity'] ?? '') . "\n";
+    $body .= "Materiaal: " . ($data['material'] ?? '') . "\n";
+    $body .= "Bericht: " . ($data['message'] ?? '') . "\n";
+
+    $mail->Body = $body;
+    $mail->send();
+    exit(0);
+} catch (Exception $e) {
+    fwrite(STDERR, $e->getMessage());
+    exit(1);
+}


### PR DESCRIPTION
## Wat
- bestel/contactformulier uitgebreid met velden voor bedrijf of particulier en honeypot
- API route stuurt mail via PHP/PHPMailer script

## Waarom
- aanvragen met meer orderinfo kunnen direct via mail binnenkomen en bots worden gefilterd

## Testplan
- [x] Build OK
- [x] Lint OK
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video
-n.v.t.


------
https://chatgpt.com/codex/tasks/task_b_68ada5fee7788332b719e4b985ff8f86