### PR TITLE
Add privacy and terms pages

### DIFF
--- a/app/(pages)/algemene-voorwaarden/page.tsx
+++ b/app/(pages)/algemene-voorwaarden/page.tsx
@@ -1,0 +1,108 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Algemene Voorwaarden – X3DPrints",
+  description:
+    "Voorwaarden voor offertes, bestellingen en leveringen bij X3DPrints.",
+  alternates: { canonical: "https://www.x3dprints.be/algemene-voorwaarden" },
+  openGraph: {
+    title: "Algemene Voorwaarden – X3DPrints",
+    description:
+      "Voorwaarden voor offertes, bestellingen en leveringen bij X3DPrints.",
+    url: "https://www.x3dprints.be/algemene-voorwaarden",
+    locale: "nl_BE",
+    siteName: "X3DPrints",
+  },
+  twitter: { card: "summary_large_image" },
+}
+
+export default function TermsPage() {
+  return (
+    <main className="px-6 py-12 sm:px-8 lg:px-12">
+      <div className="mx-auto max-w-3xl">
+        <h1 className="text-3xl font-bold tracking-tight text-slate-900">Algemene Voorwaarden</h1>
+        <ol className="mt-6 space-y-6 list-decimal pl-5">
+          <li>
+            <h2 className="text-xl font-semibold text-slate-900">Toepassing</h2>
+            <p className="mt-2 text-slate-600">
+              Deze voorwaarden zijn van toepassing op alle offertes, bestellingen en overeenkomsten met X3DPrints,
+              tenzij schriftelijk anders overeengekomen.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-xl font-semibold text-slate-900">Offertes &amp; Bestellingen</h2>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-slate-600">
+              <li>Offertes zijn 30 dagen geldig.</li>
+              <li>Een overeenkomst komt tot stand na schriftelijke bevestiging of betaling van de klant.</li>
+              <li>
+                Aangeleverde 3D-bestanden (STL/STEP) blijven eigendom van de klant, maar X3DPrints is niet
+                aansprakelijk voor schending van rechten van derden.
+              </li>
+            </ul>
+          </li>
+          <li>
+            <h2 className="text-xl font-semibold text-slate-900">Leveringen &amp; Termijnen</h2>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-slate-600">
+              <li>Levertermijnen zijn indicatief, vertraging geeft geen recht op schadevergoeding of annulatie.</li>
+              <li>Verzending gebeurt op risico van de klant, tenzij anders overeengekomen.</li>
+            </ul>
+          </li>
+          <li>
+            <h2 className="text-xl font-semibold text-slate-900">Prijzen &amp; Betaling</h2>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-slate-600">
+              <li>Alle prijzen zijn in euro, inclusief btw, tenzij anders vermeld.</li>
+              <li>Betalingstermijn: 14 dagen na factuurdatum, tenzij anders overeengekomen.</li>
+              <li>Bij laattijdige betaling: nalatigheidsintresten conform Wet van 2 augustus 2002 en administratiekosten.</li>
+            </ul>
+          </li>
+          <li>
+            <h2 className="text-xl font-semibold text-slate-900">Eigendomsvoorbehoud</h2>
+            <p className="mt-2 text-slate-600">
+              Geleverde goederen blijven eigendom van X3DPrints tot volledige betaling.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-xl font-semibold text-slate-900">Garantie &amp; Aansprakelijkheid</h2>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-slate-600">
+              <li>3D-prints zijn maatwerk en kunnen lichte toleranties of afwijkingen vertonen.</li>
+              <li>X3DPrints garandeert een correcte uitvoering volgens best mogelijke technieken.</li>
+              <li>
+                Geen aansprakelijkheid voor indirecte schade (verlies van gegevens, winstderving).
+              </li>
+              <li>Aansprakelijkheid beperkt tot het factuurbedrag van de betrokken bestelling.</li>
+            </ul>
+          </li>
+          <li>
+            <h2 className="text-xl font-semibold text-slate-900">Intellectuele eigendom</h2>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-slate-600">
+              <li>Alle door X3DPrints ontworpen modellen blijven eigendom van X3DPrints, tenzij anders schriftelijk overeengekomen.</li>
+              <li>Klanten zijn verantwoordelijk voor de rechten op bestanden die zij aanleveren.</li>
+            </ul>
+          </li>
+          <li>
+            <h2 className="text-xl font-semibold text-slate-900">Herroepingsrecht</h2>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-slate-600">
+              <li>
+                Aangezien 3D-prints maatwerk zijn, geldt het wettelijke herroepingsrecht van 14 dagen niet (art. VI.53, 3° WER).
+              </li>
+              <li>Herroepingsrecht geldt wel voor standaardproducten/accessoires.</li>
+            </ul>
+          </li>
+          <li>
+            <h2 className="text-xl font-semibold text-slate-900">Overmacht</h2>
+            <p className="mt-2 text-slate-600">
+              X3DPrints is niet aansprakelijk bij overmacht (bv. storingen, vertragingen leveranciers, technische defecten).
+            </p>
+          </li>
+          <li>
+            <h2 className="text-xl font-semibold text-slate-900">Toepasselijk recht &amp; geschillen</h2>
+            <p className="mt-2 text-slate-600">
+              Belgisch recht is van toepassing. Geschillen behoren tot de exclusieve bevoegdheid van de rechtbanken van Gent.
+            </p>
+          </li>
+        </ol>
+      </div>
+    </main>
+  )
+}
+

--- a/app/(pages)/privacy/page.tsx
+++ b/app/(pages)/privacy/page.tsx
@@ -1,0 +1,102 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Privacybeleid – X3DPrints",
+  description:
+    "Ontdek hoe X3DPrints persoonsgegevens verzamelt, gebruikt en beschermt volgens de AVG.",
+  alternates: { canonical: "https://www.x3dprints.be/privacy" },
+  openGraph: {
+    title: "Privacybeleid – X3DPrints",
+    description:
+      "Ontdek hoe X3DPrints persoonsgegevens verzamelt, gebruikt en beschermt volgens de AVG.",
+    url: "https://www.x3dprints.be/privacy",
+    locale: "nl_BE",
+    siteName: "X3DPrints",
+  },
+  twitter: { card: "summary_large_image" },
+}
+
+export default function PrivacyPage() {
+  return (
+    <main className="px-6 py-12 sm:px-8 lg:px-12">
+      <div className="mx-auto max-w-3xl">
+        <h1 className="text-3xl font-bold tracking-tight text-slate-900">Privacybeleid</h1>
+        <ol className="mt-6 space-y-6 list-decimal pl-5">
+          <li>
+            <h2 className="text-xl font-semibold text-slate-900">Verantwoordelijke voor verwerking</h2>
+            <p className="mt-2 text-slate-600">
+              X3DPrints, Provincieweg 34A, 9552 Herzele, België, ondernemingsnummer BE0681.759.451,
+              is de verantwoordelijke voor de verwerking van persoonsgegevens in de zin van de Algemene
+              Verordening Gegevensbescherming (AVG/GDPR).
+            </p>
+          </li>
+          <li>
+            <h2 className="text-xl font-semibold text-slate-900">Welke gegevens verzamelen we?</h2>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-slate-600">
+              <li>Identificatiegegevens: naam, adres, e-mailadres, telefoonnummer.</li>
+              <li>Bestel- en betaalgegevens: factuuradres, btw-nummer, betaalstatus.</li>
+              <li>Technische gegevens: IP-adres, browsergegevens, cookies (zie cookiebeleid).</li>
+              <li>3D-bestanden die klanten zelf aanleveren (STL/STEP).</li>
+            </ul>
+          </li>
+          <li>
+            <h2 className="text-xl font-semibold text-slate-900">Doeleinden van verwerking</h2>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-slate-600">
+              <li>Afhandeling van bestellingen, leveringen en betalingen.</li>
+              <li>Communicatie over offertes, projecten en klantenservice.</li>
+              <li>Boekhouding en wettelijke verplichtingen.</li>
+              <li>Marketing en promoties (enkel mits toestemming).</li>
+            </ul>
+          </li>
+          <li>
+            <h2 className="text-xl font-semibold text-slate-900">Rechtsgrond van verwerking</h2>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-slate-600">
+              <li>Contractuele noodzaak: verwerking om een bestelling of offerte uit te voeren.</li>
+              <li>Wettelijke verplichting: fiscale en boekhoudkundige verplichtingen.</li>
+              <li>Toestemming: voor nieuwsbrieven of promoties.</li>
+              <li>Gerechtvaardigd belang: basisstatistieken en beveiliging van de website.</li>
+            </ul>
+          </li>
+          <li>
+            <h2 className="text-xl font-semibold text-slate-900">Delen van gegevens</h2>
+            <p className="mt-2 text-slate-600">Gegevens worden enkel gedeeld met noodzakelijke derden zoals:</p>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-slate-600">
+              <li>Betaalproviders, logistieke partners, boekhouder.</li>
+              <li>Enkel binnen de EU of landen met passend beschermingsniveau.</li>
+            </ul>
+          </li>
+          <li>
+            <h2 className="text-xl font-semibold text-slate-900">Bewaartermijn</h2>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-slate-600">
+              <li>Facturatie- en transactiegegevens: 7 jaar (fiscale verplichting).</li>
+              <li>Marketinggegevens: tot intrekking van toestemming.</li>
+              <li>STL/STEP-bestanden: enkel zolang nodig voor de opdracht, tenzij anders overeengekomen.</li>
+            </ul>
+          </li>
+          <li>
+            <h2 className="text-xl font-semibold text-slate-900">Rechten van betrokkenen</h2>
+            <p className="mt-2 text-slate-600">
+              Recht op inzage, correctie, verwijdering, beperking, overdraagbaarheid en bezwaar. Recht om
+              toestemming in te trekken voor marketing. Klachtmogelijkheid bij de
+              Gegevensbeschermingsautoriteit (www.gegevensbeschermingsautoriteit.be).
+            </p>
+          </li>
+          <li>
+            <h2 className="text-xl font-semibold text-slate-900">Beveiliging</h2>
+            <p className="mt-2 text-slate-600">
+              X3DPrints neemt technische en organisatorische maatregelen om gegevens te beschermen tegen
+              verlies, misbruik of ongeoorloofde toegang.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-xl font-semibold text-slate-900">Contact</h2>
+            <p className="mt-2 text-slate-600">
+              Voor vragen of uitoefening van rechten: <a href="mailto:michael@xinudesign.be" className="underline-offset-2 hover:underline">michael@xinudesign.be</a>
+            </p>
+          </li>
+        </ol>
+      </div>
+    </main>
+  )
+}
+

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,7 +2,16 @@ import { MetadataRoute } from "next"
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const base = "https://www.x3dprints.be"
-  const routes = ["", "/services", "/materials", "/portfolio", "/pricing", "/contact"]
+  const routes = [
+    "",
+    "/services",
+    "/materials",
+    "/portfolio",
+    "/pricing",
+    "/contact",
+    "/privacy",
+    "/algemene-voorwaarden",
+  ]
   const now = new Date()
   return routes.map((r) => ({
     url: `${base}${r || "/"}`,

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -126,7 +126,12 @@ export default function Footer() {
               </li>
               <li>
                 <Link href="/privacy" className="hover:text-slate-900">
-                  Privacy
+                  Privacybeleid
+                </Link>
+              </li>
+              <li>
+                <Link href="/algemene-voorwaarden" className="hover:text-slate-900">
+                  Algemene voorwaarden
                 </Link>
               </li>
               <li>


### PR DESCRIPTION
## Wat
- Voeg privacybeleid en algemene voorwaarden pagina's toe
- Link naar deze pagina's in footer en sitemap

## Waarom
- Wettelijke informatie beschikbaar maken voor bezoekers

## Testplan
- [x] Build OK
- [x] Lint OK
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video


------
https://chatgpt.com/codex/tasks/task_b_68adb95e22608332a3a4d658508e29f4