### PR TITLE
feat: add complete Bambu filament catalog

### DIFF
--- a/app/(pages)/materials/page.tsx
+++ b/app/(pages)/materials/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next"
 import Reveal from "@/components/Reveal"
 import ShimmerButton from "@/components/ShimmerButton"
 import MaterialCard from "@/components/MaterialCard"
-import { MATERIALS } from "@/lib/materials"
+import { MATERIALS, MATERIAL_ORDER } from "@/lib/materials"
 
 export const metadata: Metadata = {
   title: "Materialen | X3DPrints",
@@ -13,279 +13,31 @@ export const metadata: Metadata = {
 }
 
 export default function MaterialsPage() {
-  // Helpers voor gradients en looks
-  const g = {
-    rainbow: "linear-gradient(90deg,#ef4444,#f59e0b,#22c55e,#06b6d4,#6366f1,#a855f7)",
-    sparkle: "linear-gradient(135deg,#0f172a 0%,#14532d 55%,#0f172a 100%)",
-    galaxy:
-      "radial-gradient(circle at 30% 30%,#a855f7,transparent 40%),radial-gradient(circle at 70% 60%,#22d3ee,transparent 45%),#0b1020",
-    metal: "linear-gradient(90deg,#c5ccd4,#8e9aa6,#c5ccd4)",
-    bronze: "linear-gradient(90deg,#c08a5a,#8a5b3e,#c08a5a)",
-    gunmetal: "linear-gradient(90deg,#4b5563,#6b7280,#374151)",
-    marble: "linear-gradient(135deg,#d6d3d1,#9ca3af 55%,#e7e5e4)",
-    wood: "linear-gradient(90deg,#7c5e3c,#6a4f33,#7c5e3c)",
-    translucent: (c: string) => `linear-gradient(180deg,${c}C0,${c}50)`, // C0≈75% / 50≈31% alpha
-  }
-
-  const materials = [
-    // ------- PLA families (zonder starter packs) -------
-    {
-      title: "PLA Tough+",
-      description:
-        "Taaier dan standaard PLA, behoudt vorm beter bij impact. Voor onderdelen die net iets meer mogen verdragen.",
-      features: ["Tough, minder broos", "Strakke finish", "Printvriendelijk"],
-      swatches: [
-        { label: "Geel", fill: "#f6c20f" },
-        { label: "Wit", fill: "#ffffff" },
-        { label: "Rood", fill: "#dc2626" },
-        { label: "Lichtgrijs", fill: "#cbd5e1" },
-        { label: "Blauwgrijs", fill: "#64748b" },
-        { label: "Lichtblauw", fill: "#60a5fa" },
-        { label: "Zwart", fill: "#000000" },
-      ],
-    },
-    {
-      title: "PLA Glow",
-      description: "Gloeit in het donker. Laadt op met licht, geeft een helder ‘neon’ effect in low-light.",
-      features: ["Glow-in-the-dark", "Decoratief en fun"],
-      swatches: [
-        { label: "Glow Groen", fill: "#00ff7b" },
-        { label: "Glow Geel", fill: "#faff00" },
-        { label: "Glow Blauw", fill: "#66e0ff" },
-        { label: "Glow Aqua", fill: "#66ffd9" },
-        { label: "Glow Orange", fill: "#ffb84d" },
-      ],
-    },
-    {
-      title: "PLA Marble",
-      description: "Subtiele marmerlook met spikkels. Voor elegante, luxueuze prints.",
-      features: ["Matte marmertextuur", "Stijlvolle look"],
-      swatches: [
-        { label: "Terracotta Marble", fill: "#b9654c" },
-        { label: "Marble Grey", fill: g.marble },
-        { label: "Marble White", fill: "linear-gradient(135deg,#f3f4f6,#d1d5db 55%,#f9fafb)" },
-      ],
-    },
-    {
-      title: "PLA Sparkle",
-      description: "PLA met glitterdeeltjes. Subtiel tot opvallend, afhankelijk van kleur en licht.",
-      features: ["Glitter-effect", "Diepte in oppervlak"],
-      swatches: [
-        { label: "Graphite Sparkle", fill: "linear-gradient(135deg,#1f2937,#0b1220)" },
-        { label: "Pine Sparkle", fill: "linear-gradient(135deg,#1f3d2b,#0b1220)" },
-        { label: "Wine Sparkle", fill: "linear-gradient(135deg,#3b0d18,#0b1220)" },
-        { label: "Plum Sparkle", fill: "linear-gradient(135deg,#3d1a54,#0b1220)" },
-        { label: "Mustard Sparkle", fill: "linear-gradient(135deg,#a47a1e,#3a2a00)" },
-      ],
-    },
-    {
-      title: "PLA Metal",
-      description: "Metaalachtige glans zonder conductiviteit. Ideaal voor props of industriële esthetiek.",
-      features: ["Metallic glans", "Egale lijnen"],
-      swatches: [
-        { label: "Steel", fill: g.metal },
-        { label: "Copper", fill: "#b87333" },
-        { label: "Bronze", fill: g.bronze },
-        { label: "Gunmetal", fill: g.gunmetal },
-        { label: "Graphite", fill: "linear-gradient(90deg,#1f2937,#374151,#0f172a)" },
-      ],
-    },
-    {
-      title: "PLA Galaxy",
-      description: "Diepe basiskleuren met micro-glitter voor een ‘deep space’ vibe.",
-      features: ["Diepe tinten", "Subtiele glitter"],
-      swatches: [
-        { label: "Plum Nebula", fill: g.galaxy },
-        { label: "Indigo Nebula", fill: "radial-gradient(circle at 35% 40%,#6366f1,transparent 45%),#0b1020" },
-        { label: "Teal Nebula", fill: "radial-gradient(circle at 60% 50%,#22d3ee,transparent 45%),#0b1020" },
-        { label: "Cosmos Brown", fill: "radial-gradient(circle at 40% 50%,#8b5e34,transparent 45%),#1f2937" },
-      ],
-    },
-    {
-      title: "PLA Aero",
-      description: "Lichtgewicht PLA-variant met lagere dichtheid. Voor grote, lichte modellen.",
-      features: ["Lichtgewicht", "Sneller bruikbare massa"],
-      swatches: [
-        { label: "Aero White", fill: "linear-gradient(90deg,#f8fafc,#e5e7eb,#f8fafc)" },
-        { label: "Aero Grey", fill: "#e5e7eb" },
-      ],
-    },
-    {
-      title: "PLA Silk+",
-      description: "Zijdeachtige toplaag met sterke reflectie. Perfect voor showpieces en awards.",
-      features: ["Zijdeglans", "Diepe kleuren"],
-      swatches: [
-        { label: "Black", fill: "linear-gradient(90deg,#0b0b0b,#2a2a2a,#0b0b0b)" },
-        { label: "Graphite", fill: "linear-gradient(90deg,#434343,#9e9e9e,#434343)" },
-        { label: "Silver", fill: "linear-gradient(90deg,#a0a7af,#e5e7eb,#a0a7af)" },
-        { label: "White", fill: "linear-gradient(90deg,#f8fafc,#ffffff,#f8fafc)" },
-        { label: "Champagne", fill: "linear-gradient(90deg,#c5a572,#f3d79c,#c5a572)" },
-        { label: "Copper", fill: "linear-gradient(90deg,#b66a3a,#e3a367,#b66a3a)" },
-        { label: "Gold", fill: "linear-gradient(90deg,#a36f00,#f3d36b,#a36f00)" },
-        { label: "Red", fill: "linear-gradient(90deg,#7f1d1d,#ef4444,#7f1d1d)" },
-        { label: "Green", fill: "linear-gradient(90deg,#065f46,#10b981,#065f46)" },
-        { label: "Blue", fill: "linear-gradient(90deg,#1e3a8a,#3b82f6,#1e3a8a)" },
-        { label: "Cyan", fill: "linear-gradient(90deg,#006d7e,#22d3ee,#006d7e)" },
-        { label: "Magenta", fill: "linear-gradient(90deg,#7b1fa2,#e91e63,#7b1fa2)" },
-        { label: "Rose", fill: "linear-gradient(90deg,#be185d,#f472b6,#be185d)" },
-        { label: "Sand", fill: "linear-gradient(90deg,#b59f7a,#d6c3a1,#b59f7a)" },
-        { label: "Stone", fill: "linear-gradient(90deg,#7f7f7f,#c9c9c9,#7f7f7f)" },
-      ],
-    },
-    {
-      title: "PLA Basic Gradient",
-      description: "Voorverlopen spoelen met zachte kleurovergangen. Elke print is uniek.",
-      features: ["Kleurverloop", "Decoratief"],
-      swatches: [
-        { label: "Sunset", fill: "linear-gradient(90deg,#f97316,#f43f5e,#8b5cf6)" },
-        { label: "Ocean", fill: "linear-gradient(90deg,#22d3ee,#3b82f6,#0ea5e9)" },
-        { label: "Lemonade", fill: "linear-gradient(90deg,#fde047,#fca5a5,#fcd34d)" },
-        { label: "Aurora", fill: "linear-gradient(90deg,#34d399,#22d3ee,#60a5fa)" },
-      ],
-    },
-    {
-      title: "PLA Basic",
-      description: "Klassieke PLA-lijn met brede kleurdekking. Voor algemene prints en maquettes.",
-      features: ["Veel kleuren", "Betaalbaar"],
-      swatches: [
-        { label: "White", fill: "#ffffff" },
-        { label: "Ivory", fill: "#f5f1e6" },
-        { label: "Light Grey", fill: "#d1d5db" },
-        { label: "Grey", fill: "#9ca3af" },
-        { label: "Black", fill: "#000000" },
-        { label: "Brown", fill: "#8b5a3c" },
-        { label: "Beige", fill: "#d6c3a1" },
-        { label: "Tan", fill: "#c8a46a" },
-        { label: "Yellow", fill: "#fde047" },
-        { label: "Orange", fill: "#fb923c" },
-        { label: "Coral", fill: "#f87171" },
-        { label: "Pink", fill: "#f472b6" },
-        { label: "Magenta", fill: "#db2777" },
-        { label: "Red", fill: "#ef4444" },
-        { label: "Maroon", fill: "#7f1d1d" },
-        { label: "Purple", fill: "#8b5cf6" },
-        { label: "Violet", fill: "#7c3aed" },
-        { label: "Indigo", fill: "#4f46e5" },
-        { label: "Blue", fill: "#3b82f6" },
-        { label: "Sky", fill: "#38bdf8" },
-        { label: "Teal", fill: "#14b8a6" },
-        { label: "Turquoise", fill: "#06b6d4" },
-        { label: "Cyan", fill: "#22d3ee" },
-        { label: "Mint", fill: "#86efac" },
-        { label: "Green", fill: "#22c55e" },
-        { label: "Olive", fill: "#6b8e23" },
-        { label: "Lime", fill: "#84cc16" },
-      ],
-    },
-    {
-      title: "PLA Matte",
-      description: "Matte PLA met lage glans. Verdoezelt layer-lijnen, oogt premium.",
-      features: ["Mat oppervlak", "Strakke details"],
-      swatches: [
-        { label: "White", fill: "#f5f5f5" },
-        { label: "Grey", fill: "#a3a3a3" },
-        { label: "Black", fill: "#0a0a0a" },
-        { label: "Sand", fill: "#c8b69f" },
-        { label: "Clay", fill: "#b98a6d" },
-        { label: "Terracotta", fill: "#b45309" },
-        { label: "Blush", fill: "#e9a6b1" },
-        { label: "Burgundy", fill: "#7f1d1d" },
-        { label: "Navy", fill: "#1e3a8a" },
-        { label: "Blue", fill: "#2563eb" },
-        { label: "Teal", fill: "#0f766e" },
-        { label: "Pine", fill: "#14532d" },
-        { label: "Olive", fill: "#6b8e23" },
-        { label: "Lime", fill: "#84cc16" },
-        { label: "Yellow", fill: "#facc15" },
-        { label: "Orange", fill: "#fb923c" },
-        { label: "Red", fill: "#dc2626" },
-      ],
-    },
-    {
-      title: "PLA Translucent",
-      description: "Halfdoorzichtig PLA voor lichtdoorlatende toepassingen.",
-      features: ["Lichtdoorlatend", "Sfeervol"],
-      swatches: [
-        { label: "Aqua", fill: g.translucent("#7ae5ff") },
-        { label: "Cyan", fill: g.translucent("#22d3ee") },
-        { label: "Blue", fill: g.translucent("#60a5fa") },
-        { label: "Teal", fill: g.translucent("#14b8a6") },
-        { label: "Green", fill: g.translucent("#22c55e") },
-        { label: "Red", fill: g.translucent("#ef4444") },
-        { label: "Magenta", fill: g.translucent("#db2777") },
-        { label: "Violet", fill: g.translucent("#8b5cf6") },
-        { label: "Opal", fill: g.translucent("#ffffff") },
-        { label: "Smoke", fill: g.translucent("#9ca3af") },
-      ],
-    },
-    {
-      title: "PLA Silk Multi-Color",
-      description: "Zijdeglans met ingebouwde kleurverlopen voor spectaculaire prints.",
-      features: ["Kleurverloop", "Hoge glans"],
-      swatches: [{ label: "Rainbow", fill: g.rainbow }],
-    },
-    {
-      title: "PLA-CF",
-      description:
-        "Met carbon gevuld PLA. Stijf en mat; geschikt voor jigs, panelen en functionele delen waar PLA te slap is.",
-      features: ["Stijf & licht", "Matte look"],
-      swatches: [
-        { label: "Forest Green", fill: "#3f6f3f" },
-        { label: "Brick Red", fill: "#8b3a3a" },
-        { label: "Royal Blue", fill: "#2b6cb0" },
-        { label: "Grey", fill: "#4b5563" },
-        { label: "Black", fill: "#0b0f12" },
-        { label: "Navy", fill: "#1e3a8a" },
-        { label: "Purple", fill: "#5b21b6" },
-      ],
-    },
-    {
-      title: "PLA Wood",
-      description: "PLA met houtdeeltjes. Warme, natuurlijke afwerking. Goed schuurbaar en prima te schilderen.",
-      features: ["Natuurlijke look", "Licht geurend bij print"],
-      swatches: [
-        { label: "Walnut", fill: "#6b4f2a" },
-        { label: "Mahogany", fill: "#5b3a24" },
-        { label: "Teak", fill: "#7b5838" },
-        { label: "Oak", fill: "#9b7a4e" },
-        { label: "Desert", fill: "#b99a63" },
-      ],
-    },
-
-    // ------- Functionele materialen (optioneel) -------
-    {
-      title: "PETG",
-      description:
-        "Tougher dan PLA, licht flexibel en beter bestand tegen warmte en chemicaliën. Voor functionele onderdelen.",
-      features: ["Functioneel", "Chemisch resistenter", "Vormvast"],
-      swatches: [
-        { label: "Zwart", fill: "#000000" },
-        { label: "Wit", fill: "#ffffff" },
-        { label: "Transparant", fill: g.translucent("#e6fbff") },
-        { label: "Blauw", fill: "#3b82f6" },
-        { label: "Rood", fill: "#ef4444" },
-      ],
-    },
-    {
-      title: "TPU",
-      description: "Flexibel en slijtvast. Ideaal voor grips, bumpers en demping. Vereist trager printen.",
-      features: ["Flexibel", "Schokabsorberend"],
-      swatches: [
-        { label: "Zwart", fill: "#000000" },
-        { label: "Wit", fill: "#ffffff" },
-      ],
-    },
-  ]
+  const materials = MATERIAL_ORDER.map((key) => {
+    const m = MATERIALS[key]
+    return {
+      title: m.name,
+      description: m.description,
+      features: m.features,
+      swatches: m.swatches.map((s) => ({
+        label: s.label,
+        fill: s.color,
+        inStock: s.inStock,
+      })),
+    }
+  })
 
   return (
     <main className="relative">
       <section className="px-6 pt-14 pb-8 sm:px-8 lg:px-12">
         <div className="mx-auto max-w-6xl">
           <Reveal>
-            <h1 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">Materialen</h1>
+            <h1 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
+              Materialen
+            </h1>
             <p className="mt-3 max-w-2xl text-slate-600">
-              Volledige Bambu-reeks, zonder starter packs. Kleuren hieronder zijn indicatief. Je kan later per kleur
-              <span className="font-semibold"> inStock: true</span> zetten om je voorraad te markeren.
+              Volledige Bambu-reeks, zonder starter packs. Kleuren zijn indicatief.
+              Voorraad aangeduid met <span className="font-semibold">inStock: true</span>.
             </p>
           </Reveal>
         </div>
@@ -309,13 +61,10 @@ export default function MaterialsPage() {
           <div className="font-semibold text-slate-900">Legenda</div>
           <div className="mt-2 grid gap-4 sm:grid-cols-3">
             <div className="flex items-center gap-2">
-              <span className="h-4 w-4 rounded-full bg-black" /> <span>Op voorraad (zet <code>inStock: true</code>)</span>
+              <span className="h-4 w-4 rounded-full bg-black" /> <span>Op voorraad</span>
             </div>
             <div className="flex items-center gap-2">
-              <span
-                className="relative h-4 w-4 rounded-full"
-                style={{ background: "#3b82f6" }}
-              >
+              <span className="relative h-4 w-4 rounded-full bg-slate-400">
                 <span
                   className="absolute inset-0 rounded-full"
                   style={{
@@ -329,7 +78,7 @@ export default function MaterialsPage() {
             <div className="flex items-center gap-2">
               <span
                 className="h-4 w-4 rounded-full"
-                style={{ background: g.translucent("#7ae5ff") }}
+                style={{ background: "linear-gradient(180deg,#7ae5ffc0,#7ae5ff50)" }}
               />
               <span>Translucent/glow-achtige looks</span>
             </div>
@@ -343,3 +92,4 @@ export default function MaterialsPage() {
     </main>
   )
 }
+

--- a/app/(pages)/pricing/page.tsx
+++ b/app/(pages)/pricing/page.tsx
@@ -5,6 +5,8 @@ import Reveal from "@/components/Reveal"
 import GlassCard from "@/components/GlassCard"
 import ShimmerButton from "@/components/ShimmerButton"
 import PriceEstimator from "@/components/PriceEstimator"
+import { GRAMS_PER_TIER, calcUnitPrice, type Tier } from "@/lib/pricing"
+import type { MaterialKey } from "@/lib/materials"
 
 export const metadata: Metadata = {
   title: "Prijzen 3D printen | X3DPrints",
@@ -24,41 +26,37 @@ export const metadata: Metadata = {
 }
 
 export default function Page() {
-  // Basisprijzen (PLA Matte standaard)
-  const tiers = [
+  // Indicatieve prijzen berekend via filamentkost
+  const baseMaterial: MaterialKey = "PLA_MATTE"
+  const tierDefs: Array<{ name: Tier; size: string; notes: string }> = [
     {
       name: "Small",
       size: "≤ 5 × 5 × 5 cm",
-      base: "PLA Matte (standaard)",
-      price: 9, // vanaf €9
       notes: "Kleine onderdelen, clips, testgeometrie.",
-      priceLabel: "vanaf €9 / stuk",
     },
     {
       name: "Medium",
       size: "≤ 10 × 10 × 10 cm",
-      base: "PLA Matte (standaard)",
-      price: 15,
       notes: "Prototypes, kleine behuizingen, decor.",
-      priceLabel: "vanaf €15 / stuk",
     },
     {
       name: "Large",
       size: "≤ 20 × 20 × 20 cm",
-      base: "PLA Matte (standaard)",
-      price: 30,
       notes: "Grotere delen, brackets, jigs.",
-      priceLabel: "vanaf €30 / stuk",
-    },
-    {
-      name: "XL",
-      size: "≤ 25 × 25 × 25 cm",
-      base: "PLA Matte (standaard)",
-      price: 55,
-      notes: "Maximale bouwruimte in één geheel; groter = opsplitsen.",
-      priceLabel: "vanaf €55 / stuk",
     },
   ]
+
+  const tiers = tierDefs.map((t) => {
+    const grams = GRAMS_PER_TIER[t.name]
+    const price = calcUnitPrice(t.name, baseMaterial, "Standaard")
+    return {
+      ...t,
+      base: "PLA Matte (standaard)",
+      grams,
+      price,
+      priceLabel: `≈ €${price} / stuk`,
+    }
+  })
 
   // Opslagen (ten opzichte van PLA Matte)
   const materialMods = [
@@ -150,15 +148,17 @@ export default function Page() {
                   <div className="text-xs uppercase tracking-wide text-slate-500">{t.name}</div>
                   <div className="mt-1 text-lg font-semibold text-slate-900">{t.priceLabel}</div>
                   <div className="mt-1 text-sm text-slate-700">{t.size}</div>
-                  <div className="mt-1 text-sm text-slate-500">{t.base}</div>
+                  <div className="mt-1 text-sm text-slate-500">
+                    {t.base} · ≈{t.grams}g
+                  </div>
                   <p className="mt-3 text-sm text-slate-600">{t.notes}</p>
                 </GlassCard>
               </Reveal>
             ))}
           </div>
-          <p className="mt-4 text-xs text-slate-500">
-            Prijzen zijn indicatief en incl. btw voor particulieren. Exacte prijs via modelanalyse (support, infill, oriëntatie) en gekozen materiaal/kwaliteit.
-          </p>
+            <p className="mt-4 text-xs text-slate-500">
+              Prijzen zijn indicatief op basis van Bambu-filamentprijzen (+25% marge) en ±25% infill. Exacte prijs via modelanalyse.
+            </p>
         </div>
       </section>
 

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -2,6 +2,7 @@
 "use client"
 
 import { useMemo, useState } from "react"
+import { MATERIALS } from "@/lib/materials"
 
 type FormDataShape = {
   name: string
@@ -120,17 +121,7 @@ export default function ContactForm() {
   }
 
   const materialOptions = [
-    "PLA Matte",
-    "PLA Basic",
-    "PLA Translucent",
-    "PLA Silk / Silk+",
-    "PLA Galaxy",
-    "PLA Metal",
-    "PLA Glow",
-    "PLA Wood / Marble",
-    "PLA-CF",
-    "PETG",
-    "TPU",
+    ...Object.values(MATERIALS).map(m => m.name),
     "Onzeker – graag advies",
   ]
 

--- a/components/PriceEstimator.tsx
+++ b/components/PriceEstimator.tsx
@@ -2,45 +2,24 @@
 
 import { useMemo, useState } from "react";
 import { MATERIALS } from "@/lib/materials";
+import {
+  GRAMS_PER_TIER,
+  calcUnitPrice,
+  type Tier,
+  type Quality,
+} from "@/lib/pricing";
 
 /* ========= Types ========= */
 
-type Tier = "Small" | "Medium" | "Large";
-type Quality = "Standaard" | "Fijn";
-
-type MaterialKey = keyof typeof MATERIALS | "PLA Matte" | "PETG" | "TPU"; // fallback keys
+type MaterialKey = keyof typeof MATERIALS;
 type ColorKey = string;
-
-/* ========= Pricing model (hou dit in sync met je prijzenpagina) ========= */
-
-const TIER_BASE_PRICE: Record<Tier, number> = {
-  Small: 10,
-  Medium: 15,
-  Large: 26,
-};
-
-const QUALITY_MULTIPLIER: Record<Quality, number> = {
-  Standaard: 1,
-  Fijn: 1.2,
-};
-
-const MATERIAL_MULTIPLIER: Record<MaterialKey, number> = {
-  "PLA Matte": 1,
-  PETG: 1.25, // droger-toeslag inbegrepen
-  TPU: 1.25,  // idem
-  // Als je MATERIALS gebruikt met uitgebreidere keys, defaulten we naar 1
-  ...(Object.keys(MATERIALS).reduce((acc, k) => {
-    acc[k as MaterialKey] = acc[k as MaterialKey] ?? 1;
-    return acc;
-  }, {} as Record<MaterialKey, number>)),
-};
 
 /* ========= Helpers ========= */
 
 function safeMaterialKey(key: string): MaterialKey {
-  if ((MATERIALS as any)[key]) return key as MaterialKey;
-  if (key === "PLA Matte" || key === "PETG" || key === "TPU") return key;
-  return "PLA Matte";
+  return (Object.prototype.hasOwnProperty.call(MATERIALS, key)
+    ? key
+    : "PLA_MATTE") as MaterialKey;
 }
 
 function getColorsForMaterial(material: MaterialKey): Array<{
@@ -49,44 +28,13 @@ function getColorsForMaterial(material: MaterialKey): Array<{
   inStock?: boolean;
   hex?: string;
 }> {
-  const entry = (MATERIALS as any)[material];
-  if (!entry?.swatches) {
-    // Fallbackswatches
-    if (material === "PLA Matte") {
-      return [
-        { key: "zwart", label: "Zwart", inStock: true, hex: "#0a0a0a" },
-        { key: "wit", label: "Wit", inStock: true, hex: "#f5f5f5" },
-        { key: "blauw", label: "Blauw", inStock: true, hex: "#2563eb" },
-        { key: "geel", label: "Geel", inStock: true, hex: "#facc15" },
-        { key: "groen", label: "Groen", inStock: true, hex: "#22c55e" },
-        { key: "rood", label: "Rood", inStock: true, hex: "#dc2626" },
-      ];
-    }
-    if (material === "PETG") {
-      return [
-        { key: "zwart", label: "Zwart", inStock: true, hex: "#000000" },
-        { key: "wit", label: "Wit", inStock: true, hex: "#ffffff" },
-        { key: "transparant", label: "Transparant", inStock: true, hex: "#d0f0ff" },
-      ];
-    }
-    if (material === "TPU") {
-      return [{ key: "zwart", label: "Zwart", inStock: true, hex: "#000000" }];
-    }
-    return [];
-  }
-
-  // MATERIALS.swatches kan string of object bevatten; normaliseren
-  return entry.swatches.map((s: any, i: number) => {
-    if (typeof s === "string") {
-      return { key: s, label: s, inStock: true };
-    }
-    return {
-      key: s.label ?? String(i),
-      label: s.label ?? String(i),
-      inStock: s.inStock ?? false,
-      hex: typeof s.fill === "string" && s.fill.startsWith("#") ? s.fill : undefined,
-    };
-  });
+  const entry = MATERIALS[material];
+  return entry.swatches.map((s, i) => ({
+    key: s.label ?? String(i),
+    label: s.label ?? String(i),
+    inStock: s.inStock,
+    hex: s.color,
+  }));
 }
 
 function formatCurrency(n: number): string {
@@ -96,11 +44,14 @@ function formatCurrency(n: number): string {
 /* ========= Component ========= */
 
 export default function PriceEstimator() {
+  const defaultMaterial: MaterialKey = "PLA_MATTE";
   const [tier, setTier] = useState<Tier>("Medium");
-  const [material, setMaterial] = useState<MaterialKey>("PLA Matte");
+  const [material, setMaterial] = useState<MaterialKey>(defaultMaterial);
   const [quality, setQuality] = useState<Quality>("Standaard");
   const [qty, setQty] = useState<number>(1);
-  const [color, setColor] = useState<ColorKey>("geel"); // default van PLA Matte hierboven
+  const [color, setColor] = useState<ColorKey>(
+    MATERIALS[defaultMaterial].swatches[0].label,
+  );
 
   // kleurenlijst op basis van materiaal
   const colors = useMemo(() => getColorsForMaterial(material), [material]);
@@ -112,12 +63,10 @@ export default function PriceEstimator() {
   }, [colors, color]);
 
   // prijs per stuk
-  const unitPrice = useMemo(() => {
-    const base = TIER_BASE_PRICE[tier] ?? 0;
-    const q = QUALITY_MULTIPLIER[quality] ?? 1;
-    const m = MATERIAL_MULTIPLIER[safeMaterialKey(material)] ?? 1;
-    return Math.round(base * q * m);
-  }, [tier, quality, material]);
+  const unitPrice = useMemo(
+    () => calcUnitPrice(tier, material, quality),
+    [tier, material, quality],
+  );
 
   const total = unitPrice * Math.max(1, qty);
 
@@ -125,7 +74,8 @@ export default function PriceEstimator() {
     <div className="rounded-3xl border border-slate-200/70 bg-white/80 p-6 shadow-sm backdrop-blur">
       <h3 className="text-lg font-semibold text-slate-900">Snelle prijsinschatting</h3>
       <p className="mt-1 text-sm text-slate-600">
-        Ruwe indicatie. Definitieve prijs na modelcontrole en exacte materiaalspecificaties.
+        Indicatie op basis van materiaalprijs (<span className="font-medium">25% infill</span>,{" "}
+        ≈{GRAMS_PER_TIER[tier]}g). Definitieve prijs na modelcontrole.
       </p>
 
       {/* controls */}
@@ -138,9 +88,9 @@ export default function PriceEstimator() {
             value={tier}
             onChange={(e) => setTier(e.target.value as Tier)}
           >
-            <option value="Small">Small (≤ 5 cm)</option>
-            <option value="Medium">Medium (≤ 10 cm)</option>
-            <option value="Large">Large (≤ 20 cm)</option>
+            <option value="Small">Small (≤ 5 cm · ≈{GRAMS_PER_TIER.Small}g)</option>
+            <option value="Medium">Medium (≤ 10 cm · ≈{GRAMS_PER_TIER.Medium}g)</option>
+            <option value="Large">Large (≤ 20 cm · ≈{GRAMS_PER_TIER.Large}g)</option>
           </select>
         </div>
 
@@ -152,13 +102,9 @@ export default function PriceEstimator() {
             value={material}
             onChange={(e) => setMaterial(safeMaterialKey(e.target.value))}
           >
-            <option>PLA Matte</option>
-            <option>PETG</option>
-            <option>TPU</option>
-            {/* Optioneel: toon ook alle MATERIALS-keys */}
-            {Object.keys(MATERIALS).map((k) => (
+            {Object.entries(MATERIALS).map(([k, v]) => (
               <option key={k} value={k}>
-                {k}
+                {v.name}
               </option>
             ))}
           </select>

--- a/lib/materials.ts
+++ b/lib/materials.ts
@@ -1,83 +1,392 @@
 // lib/materials.ts
-export type MaterialKey = "PLA_MATTE" | "PLA_WOOD" | "PLA_MARBLE" | "PLA_PLUS" | "PETG" | "TPU";
+
+export type MaterialKey =
+  | "PLA_TOUGH_PLUS"
+  | "PLA_GLOW"
+  | "PLA_MARBLE"
+  | "PLA_SPARKLE"
+  | "PLA_METAL"
+  | "PLA_GALAXY"
+  | "PLA_AERO"
+  | "PLA_SILK_PLUS"
+  | "PLA_BASIC_GRADIENT"
+  | "PLA_BASIC"
+  | "PLA_MATTE"
+  | "PLA_TRANSLUCENT"
+  | "PLA_SILK_MULTI_COLOR"
+  | "PLA_CF"
+  | "PLA_WOOD"
+  | "PETG"
+  | "TPU";
 
 export type Swatch = {
-  label: string;     // wat de gebruiker ziet
-  color: string;     // hex voor swatch
-  inStock: boolean;  // of je het liggen hebt
+  label: string; // wat de gebruiker ziet
+  color: string; // hex of css-gradient
+  inStock: boolean; // of je het liggen hebt
 };
 
-// Jouw huidige voorraad (zoals je eerder zei):
-// - PLA matte: zwart, wit, blauw, geel, groen, rood (op voorraad)
-// - PLA wood brown (op voorraad)
-// - PLA marble grey (op voorraad)
-// - PETG: zwart, wit, transparant (op voorraad)
-// - TPU: zwart (op voorraad)
+export type MaterialInfo = {
+  name: string;
+  description?: string;
+  features?: string[];
+  swatches: Swatch[];
+};
+
+// Gradient helpers (zelfde als oude materials page)
+const g = {
+  rainbow:
+    "linear-gradient(90deg,#ef4444,#f59e0b,#22c55e,#06b6d4,#6366f1,#a855f7)",
+  sparkle: "linear-gradient(135deg,#0f172a 0%,#14532d 55%,#0f172a 100%)",
+  galaxy:
+    "radial-gradient(circle at 30% 30%,#a855f7,transparent 40%),radial-gradient(circle at 70% 60%,#22d3ee,transparent 45%),#0b1020",
+  metal: "linear-gradient(90deg,#c5ccd4,#8e9aa6,#c5ccd4)",
+  bronze: "linear-gradient(90deg,#c08a5a,#8a5b3e,#c08a5a)",
+  gunmetal: "linear-gradient(90deg,#4b5563,#6b7280,#374151)",
+  marble: "linear-gradient(135deg,#d6d3d1,#9ca3af 55%,#e7e5e4)",
+  wood: "linear-gradient(90deg,#7c5e3c,#6a4f33,#7c5e3c)",
+  translucent: (c: string) => `linear-gradient(180deg,${c}C0,${c}50)`,
+};
+
+// Voorraad (inStock: true):
+// - PLA Matte: wit, zwart, geel, blauw, groen, oranje, roze
+// - PLA Wood: Walnut
+// - PLA Glow: Glow Groen
+// - PETG: zwart, wit, transparant
+// - TPU: zwart
 // Alles buiten dit lijstje: op bestelling (inStock: false)
 
-export const MATERIALS: Record<MaterialKey, { name: string; swatches: Swatch[] }> = {
-  PLA_MATTE: {
-    name: "PLA Matte",
+export const MATERIALS: Record<MaterialKey, MaterialInfo> = {
+  PLA_TOUGH_PLUS: {
+    name: "PLA Tough+",
+    description:
+      "Taaier dan standaard PLA, behoudt vorm beter bij impact. Voor onderdelen die net iets meer mogen verdragen.",
+    features: ["Tough, minder broos", "Strakke finish", "Printvriendelijk"],
     swatches: [
-      { label: "Zwart",  color: "#111111", inStock: true },
-      { label: "Wit",    color: "#ffffff", inStock: true },
-      { label: "Blauw",  color: "#0f52ba", inStock: true },
-      { label: "Geel",   color: "#ffd200", inStock: true },
-      { label: "Groen",  color: "#16a34a", inStock: true },
-      { label: "Rood",   color: "#d32f2f", inStock: true },
-      { label: "Paars",  color: "#7c3aed", inStock: true },
-      { label: "Oranje", color: "#fb8c00", inStock: false },
-      { label: "Roze",   color: "#e91e63", inStock: true },
+      { label: "Geel", color: "#f6c20f", inStock: false },
+      { label: "Wit", color: "#ffffff", inStock: false },
+      { label: "Rood", color: "#dc2626", inStock: false },
+      { label: "Lichtgrijs", color: "#cbd5e1", inStock: false },
+      { label: "Blauwgrijs", color: "#64748b", inStock: false },
+      { label: "Lichtblauw", color: "#60a5fa", inStock: false },
+      { label: "Zwart", color: "#000000", inStock: false },
     ],
   },
 
-  PLA_WOOD: {
-    name: "PLA Wood",
+  PLA_GLOW: {
+    name: "PLA Glow",
+    description:
+      "Gloeit in het donker. Laadt op met licht, geeft een helder ‘neon’ effect in low-light.",
+    features: ["Glow-in-the-dark", "Decoratief en fun"],
     swatches: [
-      { label: "Wood Brown", color: "#7c5e3c", inStock: true },
-      // andere “houten” tinten op bestelling
-      { label: "Light Oak",  color: "#b48a5a", inStock: false },
+      { label: "Glow Groen", color: "#00ff7b", inStock: true },
+      { label: "Glow Geel", color: "#faff00", inStock: false },
+      { label: "Glow Blauw", color: "#66e0ff", inStock: false },
+      { label: "Glow Aqua", color: "#66ffd9", inStock: false },
+      { label: "Glow Orange", color: "#ffb84d", inStock: false },
     ],
   },
 
   PLA_MARBLE: {
     name: "PLA Marble",
+    description: "Subtiele marmerlook met spikkels. Voor elegante, luxueuze prints.",
+    features: ["Matte marmertextuur", "Stijlvolle look"],
     swatches: [
-      { label: "Marble Grey", color: "#b6b6b6", inStock: true },
-      { label: "Marble White", color: "#e5e7eb", inStock: false },
+      { label: "Terracotta Marble", color: "#b9654c", inStock: false },
+      { label: "Marble Grey", color: g.marble, inStock: false },
+      {
+        label: "Marble White",
+        color: "linear-gradient(135deg,#f3f4f6,#d1d5db 55%,#f9fafb)",
+        inStock: false,
+      },
     ],
   },
 
-  PLA_PLUS: {
-    name: "PLA+ / specials",
-    // dit bevat alle fancy spul (Silk, Sparkle, Translucent, etc.) standaard op bestelling
+  PLA_SPARKLE: {
+    name: "PLA Sparkle",
+    description:
+      "PLA met glitterdeeltjes. Subtiel tot opvallend, afhankelijk van kleur en licht.",
+    features: ["Glitter-effect", "Diepte in oppervlak"],
     swatches: [
-      { label: "Silk Gold",  color: "#d4af37", inStock: false },
-      { label: "Silk Silver", color: "#c0c0c0", inStock: false },
-      { label: "Translucent Cyan", color: "#b2ebf2", inStock: false },
-      { label: "Sparkle Purple", color: "#6a1b9a", inStock: false },
+      { label: "Graphite Sparkle", color: "linear-gradient(135deg,#1f2937,#0b1220)", inStock: false },
+      { label: "Pine Sparkle", color: "linear-gradient(135deg,#1f3d2b,#0b1220)", inStock: false },
+      { label: "Wine Sparkle", color: "linear-gradient(135deg,#3b0d18,#0b1220)", inStock: false },
+      { label: "Plum Sparkle", color: "linear-gradient(135deg,#3d1a54,#0b1220)", inStock: false },
+      { label: "Mustard Sparkle", color: "linear-gradient(135deg,#a47a1e,#3a2a00)", inStock: false },
+    ],
+  },
+
+  PLA_METAL: {
+    name: "PLA Metal",
+    description:
+      "Metaalachtige glans zonder conductiviteit. Ideaal voor props of industriële esthetiek.",
+    features: ["Metallic glans", "Egale lijnen"],
+    swatches: [
+      { label: "Steel", color: g.metal, inStock: false },
+      { label: "Copper", color: "#b87333", inStock: false },
+      { label: "Bronze", color: g.bronze, inStock: false },
+      { label: "Gunmetal", color: g.gunmetal, inStock: false },
+      { label: "Graphite", color: "linear-gradient(90deg,#1f2937,#374151,#0f172a)", inStock: false },
+    ],
+  },
+
+  PLA_GALAXY: {
+    name: "PLA Galaxy",
+    description: "Diepe basiskleuren met micro-glitter voor een ‘deep space’ vibe.",
+    features: ["Diepe tinten", "Subtiele glitter"],
+    swatches: [
+      { label: "Plum Nebula", color: g.galaxy, inStock: false },
+      {
+        label: "Indigo Nebula",
+        color:
+          "radial-gradient(circle at 35% 40%,#6366f1,transparent 45%),#0b1020",
+        inStock: false,
+      },
+      {
+        label: "Teal Nebula",
+        color:
+          "radial-gradient(circle at 60% 50%,#22d3ee,transparent 45%),#0b1020",
+        inStock: false,
+      },
+      {
+        label: "Cosmos Brown",
+        color:
+          "radial-gradient(circle at 40% 50%,#8b5e34,transparent 45%),#1f2937",
+        inStock: false,
+      },
+    ],
+  },
+
+  PLA_AERO: {
+    name: "PLA Aero",
+    description:
+      "Lichtgewicht PLA-variant met lagere dichtheid. Voor grote, lichte modellen.",
+    features: ["Lichtgewicht", "Sneller bruikbare massa"],
+    swatches: [
+      {
+        label: "Aero White",
+        color: "linear-gradient(90deg,#f8fafc,#e5e7eb,#f8fafc)",
+        inStock: false,
+      },
+      { label: "Aero Grey", color: "#e5e7eb", inStock: false },
+    ],
+  },
+
+  PLA_SILK_PLUS: {
+    name: "PLA Silk+",
+    description:
+      "Zijdeachtige toplaag met sterke reflectie. Perfect voor showpieces en awards.",
+    features: ["Zijdeglans", "Diepe kleuren"],
+    swatches: [
+      { label: "Black", color: "linear-gradient(90deg,#0b0b0b,#2a2a2a,#0b0b0b)", inStock: false },
+      { label: "Graphite", color: "linear-gradient(90deg,#434343,#9e9e9e,#434343)", inStock: false },
+      { label: "Silver", color: "linear-gradient(90deg,#a0a7af,#e5e7eb,#a0a7af)", inStock: false },
+      { label: "White", color: "linear-gradient(90deg,#f8fafc,#ffffff,#f8fafc)", inStock: false },
+      { label: "Champagne", color: "linear-gradient(90deg,#c5a572,#f3d79c,#c5a572)", inStock: false },
+      { label: "Copper", color: "linear-gradient(90deg,#b66a3a,#e3a367,#b66a3a)", inStock: false },
+      { label: "Gold", color: "linear-gradient(90deg,#a36f00,#f3d36b,#a36f00)", inStock: false },
+      { label: "Red", color: "linear-gradient(90deg,#7f1d1d,#ef4444,#7f1d1d)", inStock: false },
+      { label: "Green", color: "linear-gradient(90deg,#065f46,#10b981,#065f46)", inStock: false },
+      { label: "Blue", color: "linear-gradient(90deg,#1e3a8a,#3b82f6,#1e3a8a)", inStock: false },
+      { label: "Cyan", color: "linear-gradient(90deg,#006d7e,#22d3ee,#006d7e)", inStock: false },
+      { label: "Magenta", color: "linear-gradient(90deg,#7b1fa2,#e91e63,#7b1fa2)", inStock: false },
+      { label: "Rose", color: "linear-gradient(90deg,#be185d,#f472b6,#be185d)", inStock: false },
+      { label: "Sand", color: "linear-gradient(90deg,#b59f7a,#d6c3a1,#b59f7a)", inStock: false },
+      { label: "Stone", color: "linear-gradient(90deg,#7f7f7f,#c9c9c9,#7f7f7f)", inStock: false },
+    ],
+  },
+
+  PLA_BASIC_GRADIENT: {
+    name: "PLA Basic Gradient",
+    description: "Voorverlopen spoelen met zachte kleurovergangen. Elke print is uniek.",
+    features: ["Kleurverloop", "Decoratief"],
+    swatches: [
+      { label: "Sunset", color: "linear-gradient(90deg,#f97316,#f43f5e,#8b5cf6)", inStock: false },
+      { label: "Ocean", color: "linear-gradient(90deg,#22d3ee,#3b82f6,#0ea5e9)", inStock: false },
+      { label: "Lemonade", color: "linear-gradient(90deg,#fde047,#fca5a5,#fcd34d)", inStock: false },
+      { label: "Aurora", color: "linear-gradient(90deg,#34d399,#22d3ee,#60a5fa)", inStock: false },
+    ],
+  },
+
+  PLA_BASIC: {
+    name: "PLA Basic",
+    description: "Klassieke PLA-lijn met brede kleurdekking. Voor algemene prints en maquettes.",
+    features: ["Veel kleuren", "Betaalbaar"],
+    swatches: [
+      { label: "White", color: "#ffffff", inStock: false },
+      { label: "Ivory", color: "#f5f1e6", inStock: false },
+      { label: "Light Grey", color: "#d1d5db", inStock: false },
+      { label: "Grey", color: "#9ca3af", inStock: false },
+      { label: "Black", color: "#000000", inStock: false },
+      { label: "Brown", color: "#8b5a3c", inStock: false },
+      { label: "Beige", color: "#d6c3a1", inStock: false },
+      { label: "Tan", color: "#c8a46a", inStock: false },
+      { label: "Yellow", color: "#fde047", inStock: false },
+      { label: "Orange", color: "#fb923c", inStock: false },
+      { label: "Coral", color: "#f87171", inStock: false },
+      { label: "Pink", color: "#f472b6", inStock: false },
+      { label: "Magenta", color: "#db2777", inStock: false },
+      { label: "Red", color: "#ef4444", inStock: false },
+      { label: "Maroon", color: "#7f1d1d", inStock: false },
+      { label: "Purple", color: "#8b5cf6", inStock: false },
+      { label: "Violet", color: "#7c3aed", inStock: false },
+      { label: "Indigo", color: "#4f46e5", inStock: false },
+      { label: "Blue", color: "#3b82f6", inStock: false },
+      { label: "Sky", color: "#38bdf8", inStock: false },
+      { label: "Teal", color: "#14b8a6", inStock: false },
+      { label: "Turquoise", color: "#06b6d4", inStock: false },
+      { label: "Cyan", color: "#22d3ee", inStock: false },
+      { label: "Mint", color: "#86efac", inStock: false },
+      { label: "Green", color: "#22c55e", inStock: false },
+      { label: "Olive", color: "#6b8e23", inStock: false },
+      { label: "Lime", color: "#84cc16", inStock: false },
+    ],
+  },
+
+  PLA_MATTE: {
+    name: "PLA Matte",
+    description: "Matte PLA met lage glans. Verdoezelt layer-lijnen, oogt premium.",
+    features: ["Mat oppervlak", "Strakke details"],
+    swatches: [
+      { label: "White", color: "#f5f5f5", inStock: true },
+      { label: "Grey", color: "#a3a3a3", inStock: false },
+      { label: "Black", color: "#0a0a0a", inStock: true },
+      { label: "Sand", color: "#c8b69f", inStock: false },
+      { label: "Clay", color: "#b98a6d", inStock: false },
+      { label: "Terracotta", color: "#b45309", inStock: false },
+      { label: "Blush", color: "#e9a6b1", inStock: false },
+      { label: "Burgundy", color: "#7f1d1d", inStock: false },
+      { label: "Navy", color: "#1e3a8a", inStock: false },
+      { label: "Blue", color: "#2563eb", inStock: true },
+      { label: "Teal", color: "#0f766e", inStock: false },
+      { label: "Pine", color: "#14532d", inStock: false },
+      { label: "Olive", color: "#6b8e23", inStock: false },
+      { label: "Lime", color: "#84cc16", inStock: true },
+      { label: "Yellow", color: "#facc15", inStock: true },
+      { label: "Orange", color: "#fb923c", inStock: true },
+      { label: "Red", color: "#dc2626", inStock: false },
+    ],
+  },
+
+  PLA_TRANSLUCENT: {
+    name: "PLA Translucent",
+    description: "Halfdoorzichtig PLA voor lichtdoorlatende toepassingen.",
+    features: ["Lichtdoorlatend", "Sfeervol"],
+    swatches: [
+      { label: "Aqua", color: g.translucent("#7ae5ff"), inStock: false },
+      { label: "Cyan", color: g.translucent("#22d3ee"), inStock: false },
+      { label: "Blue", color: g.translucent("#60a5fa"), inStock: false },
+      { label: "Teal", color: g.translucent("#14b8a6"), inStock: false },
+      { label: "Green", color: g.translucent("#22c55e"), inStock: false },
+      { label: "Red", color: g.translucent("#ef4444"), inStock: false },
+      { label: "Magenta", color: g.translucent("#db2777"), inStock: false },
+      { label: "Violet", color: g.translucent("#8b5cf6"), inStock: false },
+      { label: "Opal", color: g.translucent("#ffffff"), inStock: false },
+      { label: "Smoke", color: g.translucent("#9ca3af"), inStock: false },
+    ],
+  },
+
+  PLA_SILK_MULTI_COLOR: {
+    name: "PLA Silk Multi-Color",
+    description: "Zijdeglans met ingebouwde kleurverlopen voor spectaculaire prints.",
+    features: ["Kleurverloop", "Hoge glans"],
+    swatches: [{ label: "Rainbow", color: g.rainbow, inStock: false }],
+  },
+
+  PLA_CF: {
+    name: "PLA-CF",
+    description:
+      "Met carbon gevuld PLA. Stijf en mat; geschikt voor jigs, panelen en functionele delen waar PLA te slap is.",
+    features: ["Stijf & licht", "Matte look"],
+    swatches: [
+      { label: "Forest Green", color: "#3f6f3f", inStock: false },
+      { label: "Brick Red", color: "#8b3a3a", inStock: false },
+      { label: "Royal Blue", color: "#2b6cb0", inStock: false },
+      { label: "Grey", color: "#4b5563", inStock: false },
+      { label: "Black", color: "#0b0f12", inStock: false },
+      { label: "Navy", color: "#1e3a8a", inStock: false },
+      { label: "Purple", color: "#5b21b6", inStock: false },
+    ],
+  },
+
+  PLA_WOOD: {
+    name: "PLA Wood",
+    description:
+      "PLA met houtdeeltjes. Warme, natuurlijke afwerking. Goed schuurbaar en prima te schilderen.",
+    features: ["Natuurlijke look", "Licht geurend bij print"],
+    swatches: [
+      { label: "Walnut", color: "#6b4f2a", inStock: true },
+      { label: "Mahogany", color: "#5b3a24", inStock: false },
+      { label: "Teak", color: "#7b5838", inStock: false },
+      { label: "Oak", color: "#9b7a4e", inStock: false },
+      { label: "Desert", color: "#b99a63", inStock: false },
     ],
   },
 
   PETG: {
     name: "PETG",
+    description:
+      "Tougher dan PLA, licht flexibel en beter bestand tegen warmte en chemicaliën. Voor functionele onderdelen.",
+    features: ["Functioneel", "Chemisch resistenter", "Vormvast"],
     swatches: [
-      { label: "Zwart",        color: "#000000", inStock: true },
-      { label: "Wit",          color: "#ffffff", inStock: true },
-      { label: "Transparant",  color: "#c8f5f3", inStock: true },
-
-      // extra kleuren op bestelling
-      { label: "Blauw",        color: "#1976d2", inStock: false },
-      { label: "Rood",         color: "#e53935", inStock: false },
+      { label: "Zwart", color: "#000000", inStock: true },
+      { label: "Wit", color: "#ffffff", inStock: true },
+      { label: "Transparant", color: g.translucent("#e6fbff"), inStock: true },
+      { label: "Blauw", color: "#3b82f6", inStock: false },
+      { label: "Rood", color: "#ef4444", inStock: false },
     ],
   },
 
   TPU: {
     name: "TPU",
+    description:
+      "Flexibel en slijtvast. Ideaal voor grips, bumpers en demping. Vereist trager printen.",
+    features: ["Flexibel", "Schokabsorberend"],
     swatches: [
       { label: "Zwart", color: "#000000", inStock: true },
-      // TPU wit eventueel op bestelling
-      { label: "Wit",   color: "#ffffff", inStock: false },
+      { label: "Wit", color: "#ffffff", inStock: false },
     ],
   },
 };
+
+// Aankoopprijzen (€/kg) volgens Bambu-shop
+// Benaderingen; worden gebruikt voor prijsinschattingen
+export const MATERIAL_COST_EUR_PER_KG: Record<MaterialKey, number> = {
+  PLA_TOUGH_PLUS: 30,
+  PLA_GLOW: 33,
+  PLA_MARBLE: 33,
+  PLA_SPARKLE: 33,
+  PLA_METAL: 33,
+  PLA_GALAXY: 33,
+  PLA_AERO: 40,
+  PLA_SILK_PLUS: 33,
+  PLA_BASIC_GRADIENT: 29,
+  PLA_BASIC: 25,
+  PLA_MATTE: 30,
+  PLA_TRANSLUCENT: 33,
+  PLA_SILK_MULTI_COLOR: 39,
+  PLA_CF: 45,
+  PLA_WOOD: 35,
+  PETG: 30,
+  TPU: 40,
+};
+
+export const MATERIAL_ORDER: MaterialKey[] = [
+  "PLA_TOUGH_PLUS",
+  "PLA_GLOW",
+  "PLA_MARBLE",
+  "PLA_SPARKLE",
+  "PLA_METAL",
+  "PLA_GALAXY",
+  "PLA_AERO",
+  "PLA_SILK_PLUS",
+  "PLA_BASIC_GRADIENT",
+  "PLA_BASIC",
+  "PLA_MATTE",
+  "PLA_TRANSLUCENT",
+  "PLA_SILK_MULTI_COLOR",
+  "PLA_CF",
+  "PLA_WOOD",
+  "PETG",
+  "TPU",
+];
+

--- a/lib/pricing.ts
+++ b/lib/pricing.ts
@@ -1,0 +1,33 @@
+import { MATERIAL_COST_EUR_PER_KG, type MaterialKey } from "./materials";
+
+export type Tier = "Small" | "Medium" | "Large";
+
+// Ruwe gewichtsinschatting bij 25% infill
+export const GRAMS_PER_TIER: Record<Tier, number> = {
+  Small: 30,
+  Medium: 100,
+  Large: 250,
+};
+
+export type Quality = "Standaard" | "Fijn";
+export const QUALITY_MULTIPLIER: Record<Quality, number> = {
+  Standaard: 1,
+  Fijn: 1.2,
+};
+
+/**
+ * Berekent verkoopprijs per stuk op basis van filamentkost.
+ * - filamentprijs uit Bambu shop
+ * - 25% marge
+ * - schatting gewicht per formaat
+ */
+export function calcUnitPrice(
+  tier: Tier,
+  material: MaterialKey,
+  quality: Quality = "Standaard",
+): number {
+  const grams = GRAMS_PER_TIER[tier] ?? 0;
+  const costPerKg = (MATERIAL_COST_EUR_PER_KG[material] ?? 0) * 1.25;
+  const base = (grams / 1000) * costPerKg;
+  return Math.round(base * QUALITY_MULTIPLIER[quality]);
+}


### PR DESCRIPTION
## Wat
- volledige Bambu‑filamentreeks toegevoegd aan gedeelde catalogus
- materialenpagina terug in originele card‑stijl met centrale data
- prijsinschatting werkt met uitgebreid materiaaloverzicht
- prijsberekening gebaseerd op Bambu‑filamentkost (+25%) en gewicht per formaat

## Waarom
- alle Bambu‑materialen bestelbaar en gesynchroniseerd tussen pagina's
- realistischer indicatieve prijs op basis van actuele filamentprijzen

## Testplan
- [x] Build OK
- [x] Lint OK
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video


------
https://chatgpt.com/codex/tasks/task_b_68aec6a8d41083328e9701e1874ff193