### PR TITLE
feat: reorder location landing sections and add interactive visual

### DIFF
--- a/app/(pages)/[slug]/page.tsx
+++ b/app/(pages)/[slug]/page.tsx
@@ -10,6 +10,7 @@ import ShimmerButton from "@/components/ShimmerButton"
 import Catchphrase from "@/components/Catchphrase"
 import GlassOrb from "@/components/GlassOrb"
 import GlassCard from "@/components/GlassCard"
+import TiltImage from "@/components/TiltImage"
 import { renderMarkdown } from "@/lib/markdown"
 import {
   getAllLocationSlugs,
@@ -165,9 +166,84 @@ const icon = (node: ReactNode) => (
       <div aria-hidden className="pointer-events-none absolute inset-0 -z-10">
         <div className="absolute inset-0 bg-gradient-to-br from-cyan-50 via-white to-teal-50" />
         <div className="absolute -top-32 -left-28 h-[26rem] w-[26rem] rounded-full bg-cyan-200/30 blur-3xl sm:h-[32rem] sm:w-[32rem] md:h-[38rem] md:w-[38rem]" />
-        <div className="absolute -bottom-32 -right-28 h-[28rem] w-[28rem] rounded-full bg-teal-200/30 blur-3xl sm:h-[36rem] sm:w-[36rem] md:h-[42rem] md:w-[42rem]" />
-        <div className="absolute inset-0 opacity-[0.07] [background-image:radial-gradient(#000_1px,transparent_1px)] [background-size:12px_12px]" />
+      <div className="absolute -bottom-32 -right-28 h-[28rem] w-[28rem] rounded-full bg-teal-200/30 blur-3xl sm:h-[36rem] sm:w-[36rem] md:h-[42rem] md:w-[42rem]" />
+      <div className="absolute inset-0 opacity-[0.07] [background-image:radial-gradient(#000_1px,transparent_1px)] [background-size:12px_12px]" />
       </div>
+
+      {/* Tagline hero */}
+      <section className="relative px-6 pb-24 pt-20 sm:px-8 lg:px-12 lg:pb-32 lg:pt-28">
+        <div className="absolute right-0 top-0 -z-10 hidden sm:block">
+          <GlassOrb className="h-72 w-72 opacity-40" />
+        </div>
+        <div className="mx-auto max-w-6xl">
+          <Reveal className="max-w-3xl">
+            <span className="mb-4 inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs text-slate-700 backdrop-blur">
+              <span className="h-2 w-2 rounded-full bg-emerald-400" />
+              Snel, precies en betaalbaar
+            </span>
+            <Catchphrase className="mt-4 block text-base font-medium text-indigo-600 sm:text-lg">
+              Betaalbaar 3D printen
+            </Catchphrase>
+            <h1 className="mt-2 bg-gradient-to-br from-slate-900 to-slate-700 bg-clip-text text-balance text-4xl font-extrabold leading-tight tracking-tight text-transparent sm:text-5xl">
+              Where design meets dimension.
+            </h1>
+            <p className="mt-2 text-balance text-lg font-medium text-slate-700">
+              3D Prints die kloppen
+            </p>
+            <p className="mt-5 max-w-2xl text-pretty text-base leading-7 text-slate-600 sm:text-lg">
+              X3DPrints is een compacte 3D-printstudio uit Herzele, onderdeel van Xinudesign. Ideaal voor prototypes en kleine series met strakke afwerking. PLA is onze standaard, maar we schakelen waar nodig over naar PETG, ABS/ASA, Nylon of PA-CF. Levertijd meestal 2–5 werkdagen, transparante offerte vooraf.
+            </p>
+            <div className="mt-10 flex flex-wrap items-center gap-3">
+              <ShimmerButton href="/contact">Offerte aanvragen</ShimmerButton>
+              <Link
+                href="/portfolio"
+                className="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-5 py-3 text-sm font-semibold text-slate-900 backdrop-blur transition-transform hover:-translate-y-0.5 hover:bg-white/20"
+              >
+                Bekijk portfolio
+              </Link>
+            </div>
+          </Reveal>
+          <TiltImage src="/globe.svg" alt="Decoratieve wereldbol" className="mx-auto mt-12 w-64" />
+          <Reveal delay={0.15} className="mt-16 grid gap-6 sm:grid-cols-3">
+            {[
+              {
+                k: "Tolerantie",
+                v: "±0,2 mm",
+                icon: icon(
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 8h16M4 12h16M4 16h16" />
+                ),
+              },
+              {
+                k: "Doorlooptijd",
+                v: "2–5 werkdagen",
+                icon: icon(
+                  <>
+                    <circle cx={12} cy={12} r={9} />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l2 2" />
+                  </>
+                ),
+              },
+              {
+                k: "Bouwvolume",
+                v: "Tot 25 × 25 × 25 cm",
+                icon: icon(
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M21 16V8l-9-5-9 5v8l9 5 9-5ZM12 3v18M3 8l9 4 9-4"
+                  />
+                ),
+              },
+            ].map((item) => (
+              <GlassCard key={item.k} className="p-5 text-center transition-transform hover:-translate-y-1">
+                {item.icon}
+                <div className="text-sm text-slate-500">{item.k}</div>
+                <div className="mt-1 text-xl font-semibold text-slate-900">{item.v}</div>
+              </GlassCard>
+            ))}
+          </Reveal>
+        </div>
+      </section>
 
       {/* Centrale container met responsieve paddings en max breedte */}
       <section className="px-4 sm:px-6 lg:px-8 pt-12 pb-20">
@@ -249,86 +325,6 @@ const icon = (node: ReactNode) => (
             {/* glans bovenrand */}
             <div className="pointer-events-none absolute inset-x-0 -top-px h-px bg-gradient-to-r from-transparent via-white/60 to-transparent" />
           </header>
-
-          {/* HERO */}
-                <section className="relative px-6 pb-24 pt-20 sm:px-8 lg:px-12 lg:pb-32 lg:pt-28">
-                  <div className="absolute right-0 top-0 -z-10 hidden sm:block">
-                    <GlassOrb className="h-72 w-72 opacity-40" />
-                  </div>
-                  <div className="mx-auto max-w-6xl">
-                    <Reveal className="max-w-3xl">
-                      <span className="mb-4 inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs text-slate-700 backdrop-blur">
-                        <span className="h-2 w-2 rounded-full bg-emerald-400" />
-                        Snel, precies en betaalbaar
-                      </span>
-                      <Catchphrase className="mt-4 block text-base font-medium text-indigo-600 sm:text-lg">
-                        Betaalbaar 3D printen
-                      </Catchphrase>
-                      <h1 className="mt-2 bg-gradient-to-br from-slate-900 to-slate-700 bg-clip-text text-balance text-4xl font-extrabold leading-tight tracking-tight text-transparent sm:text-5xl">
-                        Where design meets dimension.
-                      </h1>
-                      <p className="mt-2 text-balance text-lg font-medium text-slate-700">
-                        3D Prints die kloppen
-                      </p>
-                      <p className="mt-5 max-w-2xl text-pretty text-base leading-7 text-slate-600 sm:text-lg">
-                        X3DPrints is een compacte 3D-printstudio uit Herzele, onderdeel van Xinudesign. Ideaal voor prototypes en
-                        kleine series met strakke afwerking. PLA is onze standaard, maar we schakelen waar nodig over naar PETG,
-                        ABS/ASA, Nylon of PA-CF. Levertijd meestal 2–5 werkdagen, transparante offerte vooraf.
-                      </p>
-                      <div className="mt-10 flex flex-wrap items-center gap-3">
-                        <ShimmerButton href="/contact">Offerte aanvragen</ShimmerButton>
-                        <Link
-                          href="/portfolio"
-                          className="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-5 py-3 text-sm font-semibold text-slate-900 backdrop-blur transition-transform hover:-translate-y-0.5 hover:bg-white/20"
-                        >
-                          Bekijk portfolio
-                        </Link>
-                      </div>
-                    </Reveal>
-          
-                    <Reveal delay={0.15} className="mt-16 grid gap-6 sm:grid-cols-3">
-                      {[
-                        {
-                          k: "Tolerantie",
-                          v: "±0,2 mm",
-                          icon: icon(
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M4 8h16M4 12h16M4 16h16" />
-                          ),
-                        },
-                        {
-                          k: "Doorlooptijd",
-                          v: "2–5 werkdagen",
-                          icon: icon(
-                            <>
-                              <circle cx={12} cy={12} r={9} />
-                              <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l2 2" />
-                            </>
-                          ),
-                        },
-                        {
-                          k: "Bouwvolume",
-                          v: "Tot 25 × 25 × 25 cm",
-                          icon: icon(
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              d="M21 16V8l-9-5-9 5v8l9 5 9-5ZM12 3v18M3 8l9 4 9-4"
-                            />
-                          ),
-                        },
-                      ].map((item) => (
-                        <GlassCard
-                          key={item.k}
-                          className="p-5 text-center transition-transform hover:-translate-y-1"
-                        >
-                          {item.icon}
-                          <div className="text-sm text-slate-500">{item.k}</div>
-                          <div className="mt-1 text-xl font-semibold text-slate-900">{item.v}</div>
-                        </GlassCard>
-                      ))}
-                    </Reveal>
-                  </div>
-                </section>
 
           {/* CONTENT (MD) – glassy + centraal + animaties + tabel-scroll */}
 <section className="relative mx-auto mt-12 max-w-3xl">

--- a/components/CtaBlock.tsx
+++ b/components/CtaBlock.tsx
@@ -1,4 +1,5 @@
 // components/ctablock.tsx
+import Link from "next/link"
 import { FaBolt, FaEnvelope, FaArrowRight, FaShieldAlt } from "react-icons/fa"
 import GlassOrb from "./GlassOrb"
 type Props = {
@@ -72,13 +73,13 @@ export default function CtaBlock({
 
           {/* Actions (geen telefoonknop) */}
           <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center">
-            <a
+            <Link
               href="/contact"
               className="has-shimmer inline-flex items-center gap-2 rounded-2xl bg-white/70 px-5 py-3 text-sm font-semibold text-slate-900 ring-1 ring-slate-900/10 backdrop-blur transition hover:bg-white/90 hover:shadow-lg"
             >
               Offerte aanvragen
               <FaArrowRight aria-hidden />
-            </a>
+            </Link>
 
             <a
               href={mailHref}

--- a/components/TiltImage.tsx
+++ b/components/TiltImage.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import Image from "next/image"
+import { useState } from "react"
+import { motion, useReducedMotion } from "framer-motion"
+
+interface TiltImageProps {
+  src: string
+  alt: string
+  className?: string
+}
+
+export default function TiltImage({ src, alt, className }: TiltImageProps) {
+  const reduce = useReducedMotion()
+  const [hovered, setHovered] = useState(false)
+
+  return (
+    <motion.div
+      className={className}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      animate={reduce ? {} : hovered ? { rotateY: 8, rotateX: -8 } : { rotateY: 0, rotateX: 0 }}
+      transition={{ type: "spring", stiffness: 200, damping: 15 }}
+    >
+      <Image src={src} alt={alt} width={400} height={400} className="h-auto w-full rounded-2xl shadow-lg" />
+    </motion.div>
+  )
+}


### PR DESCRIPTION
## Wat
- volgorde herwerkt: sloganblok nu boven stadsinformatie
- interactieve `TiltImage` voor extra visuele dynamiek
- interne CTA-link aangepast naar `Link`

## Waarom
- duidelijke hiërarchie en meer betrokkenheid op locatiepagina's

## Testplan
- [x] Build OK
- [x] Lint OK
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video


------
https://chatgpt.com/codex/tasks/task_b_68b806451580833296bafbd51f79654d