### PR TITLE
feat: add localized FAQ section

### DIFF
--- a/app/(pages)/[slug]/page.tsx
+++ b/app/(pages)/[slug]/page.tsx
@@ -19,7 +19,8 @@ import {
 } from "@/lib/locations";
 import { keywordSvgDataUri } from "@/lib/svg";
 import CtaBlock from "@/components/CtaBlock";
-import type { ReactNode } from "react"
+import Faq from "@/components/Faq";
+import type { ReactNode } from "react";
 
 interface PageProps {
   params: { slug: string };
@@ -81,16 +82,16 @@ export default async function Page({ params }: PageProps) {
   const svgSrc = keywordSvgDataUri(keyphrase);
 
   // Markdown-inhoud laden
-let contentHtml = ""
-try {
-  const file = await readFile(
-    join(process.cwd(), "content", "locations", `${loc.slug}.md`),
-    "utf8"
-  )
-  contentHtml = await renderMarkdown(file) // <-- nieuwe renderer
-} catch {
-  notFound()
-}
+  let contentHtml = "";
+  try {
+    const file = await readFile(
+      join(process.cwd(), "content", "locations", `${loc.slug}.md`),
+      "utf8",
+    );
+    contentHtml = await renderMarkdown(file); // <-- nieuwe renderer
+  } catch {
+    notFound();
+  }
 
   // JSON-LD
   const serviceJsonLd = {
@@ -104,51 +105,45 @@ try {
     keywords: [keyphrase, ...phrases],
   };
 
+  const faqItems = [
+    {
+      q: `Welke materialen kan ik laten 3D printen in ${loc.city}?`,
+      a: "We printen o.a. PLA, PETG, ABS/ASA en TPU. Op aanvraag ook technische materialen. We adviseren het juiste materiaal op basis van jouw toepassing.",
+    },
+    {
+      q: `Wat is de levertijd voor 3D printen in ${loc.city}?`,
+      a: "Meestal 2–5 werkdagen afhankelijk van complexiteit en oplage. Spoed mogelijk in overleg.",
+    },
+    {
+      q: "Kan ik een prototype of kleine serie laten maken?",
+      a: "Ja. We zijn gespecialiseerd in rapid prototyping en kleine reeksen, met opties voor nabehandeling en montage.",
+    },
+  ];
+
   const faqJsonLd = {
     "@context": "https://schema.org",
     "@type": "FAQPage",
-    mainEntity: [
-      {
-        "@type": "Question",
-        name: `Welke materialen kan ik laten 3D printen in ${loc.city}?`,
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: "We printen o.a. PLA, PETG, ABS/ASA en TPU. Op aanvraag ook technische materialen. We adviseren het juiste materiaal op basis van jouw toepassing.",
-        },
-      },
-      {
-        "@type": "Question",
-        name: `Wat is de levertijd voor 3D printen in ${loc.city}?`,
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: "Meestal 2–5 werkdagen afhankelijk van complexiteit en oplage. Spoed mogelijk in overleg.",
-        },
-      },
-      {
-        "@type": "Question",
-        name: "Kan ik een prototype of kleine serie laten maken?",
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: "Ja. We zijn gespecialiseerd in rapid prototyping en kleine reeksen, met opties voor nabehandeling en montage.",
-        },
-      },
-    ],
+    mainEntity: faqItems.map((i) => ({
+      "@type": "Question",
+      name: i.q,
+      acceptedAnswer: { "@type": "Answer", text: i.a },
+    })),
   };
 
   // Kleine helper om snel consistente outline-icons te renderen
-const icon = (node: ReactNode) => (
-  <svg
-    width="28"
-    height="28"
-    viewBox="0 0 24 24"
-    aria-hidden="true"
-    className="mx-auto mb-2 text-slate-700"
-  >
-    <g fill="none" stroke="currentColor" strokeWidth="1.6">
-      {node}
-    </g>
-  </svg>
-)
+  const icon = (node: ReactNode) => (
+    <svg
+      width="28"
+      height="28"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      className="mx-auto mb-2 text-slate-700"
+    >
+      <g fill="none" stroke="currentColor" strokeWidth="1.6">
+        {node}
+      </g>
+    </svg>
+  );
 
   const breadcrumbJsonLd = {
     "@context": "https://schema.org",
@@ -350,6 +345,7 @@ const icon = (node: ReactNode) => (
 </section>
 
 <CtaBlock city={loc.city} className="mt-14" />
+<Faq city={loc.city} items={faqItems} className="mt-14" />
 
           {/* Keyword visual — gecentreerd panel */}
           <div

--- a/components/Faq.tsx
+++ b/components/Faq.tsx
@@ -1,0 +1,43 @@
+// components/Faq.tsx
+interface FaqItem {
+  q: string
+  a: string
+}
+
+interface Props {
+  city: string
+  items: FaqItem[]
+  className?: string
+}
+
+export default function Faq({ city, items, className = "" }: Props) {
+  return (
+    <section
+      aria-labelledby="faq-title"
+      className={["relative mx-auto max-w-3xl", className].join(" ")}
+    >
+      <div className="rounded-3xl bg-white/45 p-6 sm:p-8 ring-1 ring-white/30 backdrop-blur-xl shadow-glass">
+        <h2
+          id="faq-title"
+          className="text-xl font-extrabold tracking-tight text-slate-900 dark:text-white"
+        >
+          Veelgestelde vragen over 3D printen in {city}
+        </h2>
+        <dl className="mt-6 space-y-6">
+          {items.map((item, i) => (
+            <div key={i}>
+              <dt className="font-semibold text-slate-900 dark:text-white">
+                {item.q}
+              </dt>
+              <dd className="mt-1 text-slate-700 dark:text-slate-300">
+                {item.a}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+      <div className="pointer-events-none absolute inset-x-0 -top-1 h-px bg-gradient-to-r from-transparent via-white/60 to-transparent" />
+    </section>
+  )
+}
+


### PR DESCRIPTION
## Wat
- Voeg gepersonaliseerde FAQ-sectie toe voor elke stad
- Plaats FAQ onder de CtaBlock op lokale landingspagina's

## Waarom
- Verbetert SEO en helpt AI's met contextuele antwoorden

## Testplan
- [ ] Build OK (`npm run build`)
- [x] Lint OK (`npm run lint`)
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video
- n.v.t.

------
https://chatgpt.com/codex/tasks/task_b_68b80944c47c8332be65b5c7b822d539