### PR TITLE
feat: load portfolio images from directory

### DIFF
--- a/app/(pages)/portfolio/page.tsx
+++ b/app/(pages)/portfolio/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next"
 import Link from "next/link"
-import Image from "next/image"
 import AutoCarousel from "@/components/AutoCarousel"
 import GlassOrb from "@/components/GlassOrb"
 import ShimmerButton from "@/components/ShimmerButton"
+import { readdirSync } from "node:fs"
+import path from "node:path"
 
 export const metadata: Metadata = {
   title: "Portfolio 3D prints | X3DPrints",
@@ -20,20 +21,20 @@ export const metadata: Metadata = {
   twitter: { card: "summary_large_image" },
 }
 
-const photos = [
-  { src: "/portfolio/fleshouder.jpg", alt: "3D geprinte fleshouder", info: "PLA Matte, 0.2 mm, 3 u printtijd" },
-  { src: "/portfolio/mesh-houder.jpg", alt: "Wireless mesh houder", info: "PETG zwart, 0.2 mm, hittebestendig" },
-  { src: "/portfolio/naamletter.jpg", alt: "Naamletter als babycadeau", info: "PLA zijdeglans, gepolijst" },
-  { src: "/portfolio/octopus.jpg", alt: "Articulated octopus", info: "PLA, articulaties direct uit de printer" },
-  { src: "/portfolio/kerstboom-transparant.jpg", alt: "Transparante kerstboom", info: "PETG transparant, 0.28 mm" },
-  { src: "/portfolio/tpu-case.jpg", alt: "TPU Samsung S24 Ultra case", info: "TPU 95A, flexibele bescherming" },
-]
-
-// Placeholder fallback voor ontbrekende bestanden (optioneel)
-// Je kunt dit blok verwijderen zodra je echte foto's plaatst.
-for (const p of photos) {
-  if (!p.src) p.src = "/Logo.webp"
-}
+const portfolioDir = path.join(process.cwd(), "public/images/portfolio")
+const photos = readdirSync(portfolioDir)
+  .filter((f) => /\.(?:png|jpe?g|webp)$/i.test(f))
+  .map((file) => {
+    const alt = file
+      .replace(/\.[^.]+$/, "")
+      .replace(/[-_]/g, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+    return {
+      src: `/images/portfolio/${encodeURIComponent(file)}`,
+      alt,
+    }
+  })
 
 const videos = [
   { id: "tVDwEw3Od-8", title: "3D geprinte fleshouder", description: "Praktische fleshouder, laag per laag opgebouwd in PLA." },
@@ -64,7 +65,7 @@ const imageJsonLd = {
     "@type": "ImageObject",
     contentUrl: `https://www.x3dprints.be${p.src}`,
     name: p.alt,
-    description: p.info || p.alt,
+    description: p.alt,
   })),
 }
 
@@ -122,7 +123,7 @@ export default function Page() {
 
           {/* Carousel */}
           <h2 className="mt-12 text-2xl font-bold tracking-tight text-slate-900">Afbeeldingen</h2>
-          <p className="mt-2 text-slate-600">Hover om te pauzeren. Klik voor details.</p>
+          <p className="mt-2 text-slate-600">Gebruik de pijlen om te navigeren. Klik voor details.</p>
           <div className="mt-6">
             <AutoCarousel items={photos} speed={20}  />
           </div>

--- a/components/AutoCarousel.tsx
+++ b/components/AutoCarousel.tsx
@@ -1,8 +1,9 @@
 "use client"
 
 import Image from "next/image"
-import { useMemo, useState, useEffect } from "react"
+import { useState, useEffect } from "react"
 import { createPortal } from "react-dom"
+import { FaChevronLeft, FaChevronRight } from "react-icons/fa"
 
 type Photo = {
   src: string
@@ -15,8 +16,7 @@ type Photo = {
 export default function AutoCarousel({
   items,
   className = "",
-  speed = 30, // seconden per volledige loop
-  // grotere hoogte out-of-the-box
+  speed = 5,
   itemClass = "h-[360px] sm:h-[420px] lg:h-[500px]",
 }: {
   items: Photo[]
@@ -26,11 +26,20 @@ export default function AutoCarousel({
   itemClass?: string
 }) {
   const [active, setActive] = useState<Photo | null>(null)
+  const [index, setIndex] = useState(0)
   const [mounted, setMounted] = useState(false)
   useEffect(() => setMounted(true), [])
 
-  // Dubbele lijst voor naadloze loop
-  const loop = useMemo(() => [...items, ...items], [items])
+  useEffect(() => {
+    if (items.length <= 1) return
+    const id = setInterval(() => {
+      setIndex((i) => (i + 1) % items.length)
+    }, speed * 1000)
+    return () => clearInterval(id)
+  }, [items.length, speed])
+
+  const prev = () => setIndex((i) => (i - 1 + items.length) % items.length)
+  const next = () => setIndex((i) => (i + 1) % items.length)
 
   return (
     <section
@@ -40,56 +49,57 @@ export default function AutoCarousel({
         className,
       ].join(" ")}
     >
-      {/* zachte gradient-glow */}
       <div aria-hidden className="pointer-events-none absolute inset-0 rounded-3xl bg-gradient-to-r from-cyan-200/30 via-transparent to-teal-200/30" />
 
-      {/* Track */}
-      <div
-        className={`
-          relative flex gap-4 p-4
-          [animation:marquee_linear_infinite]
-          group-hover:[animation-play-state:paused]
-        `}
-        style={{ animationDuration: `${speed}s` }}
-      >
-        {loop.map((p, i) => (
-          <button
-            key={`${p.src}-${i}`}
-            onClick={() => setActive(p)}
-            aria-label={`Vergroot afbeelding: ${p.alt}`}
-            className={[
-              // grotere hoogte + vaste aspect
-              "relative isolate z-0 aspect-[4/3] min-w-[260px] w-[72vw] max-w-[680px]",
-              "overflow-hidden rounded-2xl border border-white/30 bg-white/60",
-              "shadow-[0_10px_40px_rgba(0,0,0,0.06)] backdrop-blur",
-              "transition-transform duration-300 hover:-translate-y-0.5",
-              itemClass,
-            ].join(" ")}
-          >
-            {/* Shine on hover */}
-            <span
-              aria-hidden
-              className="
-                pointer-events-none absolute inset-0 -translate-x-full bg-[linear-gradient(115deg,transparent,rgba(255,255,255,.55),transparent)]
-                transition-transform duration-700 group-hover:translate-x-full
-              "
-            />
-            <Image
-              src={p.src}
-              alt={p.alt}
-              fill
-              sizes="(max-width: 768px) 80vw, (max-width: 1200px) 50vw, 680px"
-              className="object-cover"
-              priority={i < 2}
-            />
-            <span className="absolute bottom-2 left-2 rounded-md bg-white/75 px-2 py-1 text-[12px] font-medium text-slate-800 backdrop-blur">
-              {p.alt}
-            </span>
-          </button>
-        ))}
+      <div className="relative w-full overflow-hidden">
+        <div className={`relative ${itemClass}`}>
+          {items.map((p, i) => (
+            <button
+              key={p.src}
+              onClick={() => setActive(p)}
+              aria-label={`Vergroot afbeelding: ${p.alt}`}
+              className={[
+                "absolute inset-0 w-full overflow-hidden rounded-2xl border border-white/30 bg-white/60",
+                "shadow-[0_10px_40px_rgba(0,0,0,0.06)] backdrop-blur",
+                "transition-opacity duration-700",
+                i === index ? "opacity-100" : "pointer-events-none opacity-0",
+              ].join(" ")}
+            >
+              <Image
+                src={p.src}
+                alt={p.alt}
+                fill
+                sizes="(max-width: 768px) 80vw, (max-width: 1200px) 50vw, 680px"
+                className="object-cover"
+                priority={i === index}
+              />
+              <span className="absolute bottom-2 left-2 rounded-md bg-white/75 px-2 py-1 text-[12px] font-medium text-slate-800 backdrop-blur">
+                {p.alt}
+              </span>
+            </button>
+          ))}
+        </div>
+
+        {items.length > 1 && (
+          <>
+            <button
+              aria-label="Vorige afbeelding"
+              onClick={prev}
+              className="absolute left-3 top-1/2 inline-flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-lg bg-white/85 text-slate-900 shadow-sm backdrop-blur transition hover:bg-white"
+            >
+              <FaChevronLeft aria-hidden />
+            </button>
+            <button
+              aria-label="Volgende afbeelding"
+              onClick={next}
+              className="absolute right-3 top-1/2 inline-flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-lg bg-white/85 text-slate-900 shadow-sm backdrop-blur transition hover:bg-white"
+            >
+              <FaChevronRight aria-hidden />
+            </button>
+          </>
+        )}
       </div>
 
-      {/* Lightbox via portal zodat niets wordt afgeknipt */}
       {mounted && active &&
         createPortal(
           <div
@@ -107,14 +117,13 @@ export default function AutoCarousel({
               onClick={(e) => e.stopPropagation()}
             >
               <div className="relative w-full overflow-hidden rounded-xl">
-                {/* hoge view: neem viewport-hoogte, respecteer video-aspect */}
                 <div className="relative mx-auto h-[72vh] max-h-[900px] w-full">
                   <Image
                     src={active.src}
                     alt={active.alt}
                     fill
                     sizes="100vw"
-                    className="object-contain" // geen crop in modal
+                    className="object-contain"
                     priority
                   />
                 </div>
@@ -135,7 +144,6 @@ export default function AutoCarousel({
               </div>
             </div>
 
-            {/* Close via ESC */}
             <script
               dangerouslySetInnerHTML={{
                 __html: `
@@ -149,22 +157,16 @@ export default function AutoCarousel({
                 `,
               }}
             />
-            {/* Hidden click target for ESC helper */}
             <button data-x3d-close onClick={() => setActive(null)} className="hidden" />
           </div>,
           document.body
         )
       }
 
-      {/* keyframes + motion-reduce */}
       <style
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{
           __html: `
-          @keyframes marquee {
-            from { transform: translateX(0) }
-            to   { transform: translateX(-50%) }
-          }
           @keyframes fadeIn {
             from { opacity:0 } to { opacity:1 }
           }
@@ -172,9 +174,9 @@ export default function AutoCarousel({
             from { opacity:0; transform: scale(.985) translateY(6px) }
             to   { opacity:1; transform: scale(1) translateY(0) }
           }
-          .group [style*="animation"] { animation-timing-function: linear }
           @media (prefers-reduced-motion: reduce) {
-            .group [style*="animation"] { animation: none !important }
+            .animate-[fadeIn_.2s_ease-out_both],
+            .animate-[popIn_.18s_ease-out_both] { animation: none !important }
           }
         `,
         }}
@@ -182,3 +184,4 @@ export default function AutoCarousel({
     </section>
   )
 }
+


### PR DESCRIPTION
## Wat
- laad alle portfolio-afbeeldingen automatisch uit `public/images/portfolio`
- voeg handmatige vorige/volgende navigatie toe aan de carrousel

## Waarom
- galerij blijft automatisch up-to-date
- bezoekers kunnen zelf door de afbeeldingen bladeren

## Testplan
- [ ] Build OK
- [x] Lint OK
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video


------
https://chatgpt.com/codex/tasks/task_b_68b820911b4883329b1bc28a1e445e6a