### PR TITLE
feat: add markdown content component

### DIFF
--- a/app/(pages)/[slug]/page.tsx
+++ b/app/(pages)/[slug]/page.tsx
@@ -11,6 +11,7 @@ import Catchphrase from "@/components/Catchphrase"
 import GlassOrb from "@/components/GlassOrb"
 import GlassCard from "@/components/GlassCard"
 import TiltImage from "@/components/TiltImage"
+import Markdown from "@/components/Markdown"
 import { renderMarkdown } from "@/lib/markdown"
 import {
   getAllLocationSlugs,
@@ -368,10 +369,7 @@ export default async function Page({ params }: PageProps) {
   >
     {/* scroll wrapper zorgt dat tabellen zichtbaar blijven op mobiel */}
     <div className="table-wrap overflow-x-auto">
-      <article
-  className="prose prose-slate lg:prose-lg dark:prose-invert prose-x3d leading-relaxed mt-8 max-w-none"
-  dangerouslySetInnerHTML={{ __html: contentHtml }}
-/>
+      <Markdown html={contentHtml} className="mt-8 max-w-none" />
     </div>
   </div>
 

--- a/components/Markdown.tsx
+++ b/components/Markdown.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@/lib/utils"
+
+interface MarkdownProps {
+  html: string
+  className?: string
+}
+
+export default function Markdown({ html, className }: MarkdownProps) {
+  return (
+    <article
+      className={cn(
+        "prose prose-slate lg:prose-lg dark:prose-invert prose-x3d leading-relaxed",
+        className,
+      )}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
+}


### PR DESCRIPTION
## Wat
- centralizes landing page markdown styling into reusable component

## Waarom
- improves readability of local landing page content and reduces duplication

## Testplan
- [ ] Build OK (`npm run build`)
- [x] Lint OK (`npm run lint`)
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video


------
https://chatgpt.com/codex/tasks/task_b_68b83977827c83329797f04286c8afca