### PR TITLE
feat: add markdown content component

### DIFF
--- a/app/(pages)/[slug]/page.tsx
+++ b/app/(pages)/[slug]/page.tsx
@@ -11,7 +11,7 @@ import Catchphrase from "@/components/Catchphrase"
 import GlassOrb from "@/components/GlassOrb"
 import GlassCard from "@/components/GlassCard"
 import TiltImage from "@/components/TiltImage"
-import { renderMarkdown } from "@/lib/markdown"
+import Markdown from "@/components/Markdown"
 import {
   getAllLocationSlugs,
   getLocationBySlug,
@@ -82,13 +82,12 @@ export default async function Page({ params }: PageProps) {
   const svgSrc = keywordSvgDataUri(keyphrase);
 
   // Markdown-inhoud laden
-  let contentHtml = "";
+  let contentMd = "";
   try {
-    const file = await readFile(
+    contentMd = await readFile(
       join(process.cwd(), "content", "locations", `${loc.slug}.md`),
       "utf8",
     );
-    contentHtml = await renderMarkdown(file); // <-- nieuwe renderer
   } catch {
     notFound();
   }
@@ -368,10 +367,7 @@ export default async function Page({ params }: PageProps) {
   >
     {/* scroll wrapper zorgt dat tabellen zichtbaar blijven op mobiel */}
     <div className="table-wrap overflow-x-auto">
-      <article
-  className="prose prose-slate lg:prose-lg dark:prose-invert prose-x3d leading-relaxed mt-8 max-w-none"
-  dangerouslySetInnerHTML={{ __html: contentHtml }}
-/>
+      <Markdown source={contentMd} className="mt-8 max-w-none" />
     </div>
   </div>
 

--- a/components/Markdown.tsx
+++ b/components/Markdown.tsx
@@ -1,0 +1,20 @@
+import { cn } from "@/lib/utils"
+import { renderMarkdown } from "@/lib/markdown"
+
+interface MarkdownProps {
+  source: string
+  className?: string
+}
+
+export default async function Markdown({ source, className }: MarkdownProps) {
+  const html = await renderMarkdown(source)
+  return (
+    <article
+      className={cn(
+        "prose prose-slate lg:prose-lg dark:prose-invert prose-x3d leading-relaxed",
+        className,
+      )}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
+}


### PR DESCRIPTION
## Wat
- render raw Markdown with unified and Tailwind Typography
- update local landing pages to use Markdown component

## Waarom
- ensures clear headings, lists and links for local landing page content

## Testplan
- [ ] Build OK (`npm run build`)
- [x] Lint OK (`npm run lint`)
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video


------
https://chatgpt.com/codex/tasks/task_b_68b83977827c83329797f04286c8afca