### PR TITLE
fix: enable styled markdown rendering

### DIFF
--- a/components/Markdown.tsx
+++ b/components/Markdown.tsx
@@ -1,5 +1,4 @@
 import { cn } from "@/lib/utils"
-
 import { renderMarkdown } from "@/lib/markdown"
 
 interface MarkdownProps {
@@ -12,9 +11,11 @@ export default async function Markdown({ source, className }: MarkdownProps) {
 
   return (
     <article
-  className="prose prose-slate lg:prose-lg dark:prose-invert prose-x3d leading-relaxed"
-  dangerouslySetInnerHTML={{ __html: html }}
-/>
-
+      className={cn(
+        "prose prose-slate lg:prose-lg dark:prose-invert prose-x3d leading-relaxed",
+        className,
+      )}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
   )
 }

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -4,20 +4,18 @@ import remarkParse from "remark-parse"
 import remarkGfm from "remark-gfm"
 import remarkRehype from "remark-rehype"
 import rehypeRaw from "rehype-raw"
-import rehypeSanitize from "rehype-sanitize"
+import rehypeSanitize, { type Schema } from "rehype-sanitize"
 import rehypeStringify from "rehype-stringify"
 
 /**
  * Minimal, expliciet sanitize schema zodat headings, lijsten, tabellen,
  * codeblokken, images en links blijven bestaan. Geen 'any', geen JSON hacks.
  */
-type SanitizeSchema = {
-  tagNames?: string[]
-  attributes?: Record<string, Array<string | [string]>>
+interface SafeSchema extends Schema {
   protocols?: Record<string, string[]>
 }
 
-const safeSchema: SanitizeSchema = {
+const safeSchema: SafeSchema = {
   tagNames: [
     "a","abbr","b","blockquote","br","code","em","i","img","hr","kbd","mark","s","strong","sub","sup","u",
     "p","h1","h2","h3","h4","h5","h6",
@@ -55,7 +53,7 @@ export async function renderMarkdown(markdown: string): Promise<string> {
     .use(remarkGfm)
     .use(remarkRehype, { allowDangerousHtml: true })
     .use(rehypeRaw)
-    .use(rehypeSanitize, safeSchema as unknown as any) // rehype-sanitize verwacht een Schema; structureel compatibel
+    .use(rehypeSanitize, safeSchema)
     .use(rehypeStringify)
     .process(markdown)
 


### PR DESCRIPTION
## Wat
- Type-safe sanitize schema for markdown rendering
- Markdown component accepts custom class names for layout

## Waarom
- Lint error in markdown utilities
- Landing pages need richer markdown styling

## Testplan
- [ ] Build OK (fails: Invalid segment configuration export)
- [x] Lint OK
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video


------
https://chatgpt.com/codex/tasks/task_b_68b8a8d70af88332ab58b96a6bb9a578