### PR TITLE
fix: enable styled markdown rendering

### DIFF
--- a/app/(pages)/[slug]/page.tsx
+++ b/app/(pages)/[slug]/page.tsx
@@ -28,7 +28,7 @@ interface PageProps {
 }
 
 export const dynamicParams = false;
-export const revalidate = 60 * 60 * 24; // 24u cache
+export const revalidate = 86400; // 24u cache
 
 export function generateStaticParams() {
   return getAllLocationSlugs().map((slug) => ({ slug }));
@@ -359,9 +359,7 @@ export default async function Page({ params }: PageProps) {
           {/* CONTENT (MD) – glassy + centraal + animaties + tabel-scroll */}
 <section className="relative mx-auto mt-12 max-w-3xl">
   <div className="rounded-3xl bg-white/45 p-6 sm:p-8 ring-1 ring-white/30 backdrop-blur-xl shadow-glass">
-  <div className="overflow-x-auto">
-    <Markdown source={contentMd} className="max-w-none" />
-  </div>
+  <Markdown source={contentMd} className="max-w-none" />
 </div>
 
 

--- a/app/(pages)/locaties/page.tsx
+++ b/app/(pages)/locaties/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link"
 import GlassOrb from "@/components/GlassOrb"
 import { getAllLocationSlugs, getLocationBySlug } from "@/lib/locations"
 
-export const revalidate = 60 * 60 * 6 // 6u heropbouw
+export const revalidate = 21600 // 6u heropbouw
 
 export const metadata: Metadata = {
   title: "3D printen per stad | X3DPrints",

--- a/components/Markdown.tsx
+++ b/components/Markdown.tsx
@@ -1,5 +1,4 @@
 import { cn } from "@/lib/utils"
-
 import { renderMarkdown } from "@/lib/markdown"
 
 interface MarkdownProps {
@@ -11,10 +10,14 @@ export default async function Markdown({ source, className }: MarkdownProps) {
   const html = await renderMarkdown(source)
 
   return (
-    <article
-  className="prose prose-slate lg:prose-lg dark:prose-invert prose-x3d leading-relaxed"
-  dangerouslySetInnerHTML={{ __html: html }}
-/>
-
+    <div className="overflow-x-auto">
+      <article
+        className={cn(
+          "prose prose-slate lg:prose-lg dark:prose-invert prose-x3d leading-relaxed",
+          className,
+        )}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </div>
   )
 }

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -4,20 +4,18 @@ import remarkParse from "remark-parse"
 import remarkGfm from "remark-gfm"
 import remarkRehype from "remark-rehype"
 import rehypeRaw from "rehype-raw"
-import rehypeSanitize from "rehype-sanitize"
+import rehypeSanitize, { type Schema } from "rehype-sanitize"
 import rehypeStringify from "rehype-stringify"
 
 /**
  * Minimal, expliciet sanitize schema zodat headings, lijsten, tabellen,
  * codeblokken, images en links blijven bestaan. Geen 'any', geen JSON hacks.
  */
-type SanitizeSchema = {
-  tagNames?: string[]
-  attributes?: Record<string, Array<string | [string]>>
+interface SafeSchema extends Schema {
   protocols?: Record<string, string[]>
 }
 
-const safeSchema: SanitizeSchema = {
+const safeSchema: SafeSchema = {
   tagNames: [
     "a","abbr","b","blockquote","br","code","em","i","img","hr","kbd","mark","s","strong","sub","sup","u",
     "p","h1","h2","h3","h4","h5","h6",
@@ -55,7 +53,7 @@ export async function renderMarkdown(markdown: string): Promise<string> {
     .use(remarkGfm)
     .use(remarkRehype, { allowDangerousHtml: true })
     .use(rehypeRaw)
-    .use(rehypeSanitize, safeSchema as unknown as any) // rehype-sanitize verwacht een Schema; structureel compatibel
+    .use(rehypeSanitize, safeSchema)
     .use(rehypeStringify)
     .process(markdown)
 


### PR DESCRIPTION
## Wat
- Wrap Markdown output in scroll container to preserve prose styling and avoid hydration mismatches
- Use numeric revalidate values for valid segment config

## Waarom
- Markdown layout was unstyled and triggered hydration errors
- Build previously failed on invalid segment configuration

## Testplan
- [x] Build OK
- [x] Lint OK
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video


------
https://chatgpt.com/codex/tasks/task_b_68b8a8d70af88332ab58b96a6bb9a578