### PR TITLE
feat: colorize services page and expand faq

### DIFF
--- a/app/(pages)/services/page.tsx
+++ b/app/(pages)/services/page.tsx
@@ -6,14 +6,16 @@ import {
 } from "lucide-react"
 import Reveal from "@/components/Reveal"
 import GlassCard from "@/components/GlassCard"
+import CtaBlock from "@/components/CtaBlock"
+import Faq from "@/components/Faq"
 
 export const metadata: Metadata = {
-  title: "3D Print Services | FDM, nabewerking & montage",
+  title: "3D Print Service België | Prototypes, Nabewerking & Montage",
   description:
-    "Professionele FDM 3D-printservice voor prototypes en kleine series. Materiaaladvies, nabewerking, inserts en montage. Regio Herzele/Gent.",
+    "Professionele 3D print service in Herzele/Gent voor prototypes en kleine series. Snelle FDM prints, materiaaladvies, nabewerking en montage.",
   alternates: { canonical: "https://www.x3dprints.be/services" },
   openGraph: {
-    title: "3D Print Services",
+    title: "3D Print Service België",
     description:
       "Van STL/STEP naar strakke, functionele prints. Snel, betaalbaar en consistent, met afwerking op maat.",
     url: "https://www.x3dprints.be/services",
@@ -126,20 +128,104 @@ export default function Page() {
 
   const faq = [
     {
-      q: "Welke 3D-bestanden zijn ideaal?",
-      a: "STL of STEP. Voeg context toe: functie, omgeving (hitte/UV), kleur en gewenste afwerking.",
+      q: "Wat is 3D printen precies?",
+      a: "3D printen is een digitale productietechniek waarbij een object laag per laag wordt opgebouwd op basis van een 3D-bestand, meestal in STL- of STEP-formaat.",
+    },
+    {
+      q: "Welke materialen gebruiken jullie voor 3D printen?",
+      a: "Wij printen standaard in PLA, PETG en TPU, elk met eigen eigenschappen. PLA is detailrijk, PETG is sterker en hittebestendig, TPU is flexibel.",
+    },
+    {
+      q: "Kan ik een bestand aanleveren voor 3D printen?",
+      a: "Ja, je kan je .STL- of .STEP-bestand uploaden of mailen. Wij zorgen voor de voorbereiding en productie.",
+    },
+    {
+      q: "Moet ik ervaring hebben met 3D design om iets te laten printen?",
+      a: "Nee, wij kunnen je ondersteunen bij het optimaliseren van je ontwerp en adviseren over materiaalkeuze.",
+    },
+    {
+      q: "Hoe snel kan ik mijn 3D print ontvangen?",
+      a: "Onze standaard levertijd is 2–5 werkdagen, afhankelijk van complexiteit en oplage. Spoed is mogelijk op aanvraag.",
+    },
+    {
+      q: "Wat kost 3D printen?",
+      a: "De prijs hangt af van materiaal, printtijd, nabewerking en aantal stuks. Wij werken met een transparante prijsberekening.",
+    },
+    {
+      q: "Kan ik meerdere stuks tegelijk laten printen?",
+      a: "Ja, we bieden zowel prototypes als kleine series aan. Voor grotere aantallen maken we een offerte op maat.",
+    },
+    {
+      q: "Kunnen jullie ook prototypes printen?",
+      a: "Ja, onze service richt zich sterk op rapid prototyping, zodat je ontwerp snel getest kan worden.",
+    },
+    {
+      q: "Is 3D printen geschikt voor functionele onderdelen?",
+      a: "Ja, met materialen zoals PETG en TPU produceren we functionele onderdelen die gebruikt kunnen worden in dagelijkse toepassingen.",
+    },
+    {
+      q: "Bieden jullie nabewerking aan voor 3D prints?",
+      a: "Ja, we kunnen prints schuren, lakken of assembleren afhankelijk van jouw wensen.",
+    },
+    {
+      q: "Voor welke sectoren is 3D printen interessant?",
+      a: "3D printen is nuttig voor ondernemers, kmo’s, onderwijs, architectuur, productontwikkeling, hobbyisten en verenigingen.",
+    },
+    {
+      q: "Hoe lever ik mijn 3D model het best aan?",
+      a: "Gebruik bij voorkeur .STL of .STEP, voeg notities toe over sterkte, afwerking en aantallen.",
+    },
+    {
+      q: "Wat als mijn bestand niet correct is?",
+      a: "Wij controleren je bestand en geven advies of kleine correcties doorvoeren zodat het printbaar is.",
+    },
+    {
+      q: "Kan ik een 3D print laten maken zonder ontwerp?",
+      a: "Ja, wij kunnen je helpen bij het opmaken van een eenvoudig 3D ontwerp op basis van jouw idee of schets.",
+    },
+    {
+      q: "Worden mijn bestanden vertrouwelijk behandeld?",
+      a: "Ja, alle aangeleverde bestanden worden strikt vertrouwelijk behandeld en enkel gebruikt voor jouw bestelling.",
+    },
+    {
+      q: "Hoe groot kunnen jullie 3D prints zijn?",
+      a: "Onze printcapaciteit hangt af van het materiaal en de printer, maar we kunnen zowel kleine details als grotere objecten produceren.",
+    },
+    {
+      q: "Welke afwerkingen zijn mogelijk?",
+      a: "Afhankelijk van de toepassing kunnen we prints leveren onafgewerkt, geschuurd, geverfd of gecoat.",
+    },
+    {
+      q: "Kunnen jullie ook onderdelen namaken of vervangen?",
+      a: "Ja, mits een goed 3D model of fysiek voorbeeld kunnen we reserveonderdelen of custom componenten printen.",
+    },
+    {
+      q: "Is 3D printen duurzaam?",
+      a: "Ja, 3D printen produceert minder afval dan klassieke productiemethoden. PLA is bovendien een biogebaseerd materiaal.",
+    },
+    {
+      q: "Hoe vraag ik een offerte aan voor 3D printen?",
+      a: "Upload je bestand via de contactpagina of mail ons. Je ontvangt binnen 24 uur een duidelijke prijsindicatie.",
     },
     {
       q: "Welke regio leveren jullie?",
       a: "Herzele/Gent als uitvalsbasis. Verzenden binnen België of afhalen in overleg.",
     },
     {
-      q: "Doen jullie nabehandeling en montage?",
-      a: "Ja. Schuren, primen en lakken. Inserts, lijmen en basis-assemblage mogelijk.",
-    },
-    {
       q: "Hoe snel krijg ik een offerte?",
       a: "Meestal binnen 24 uur na je aanvraag met model en korte beschrijving.",
+    },
+    {
+      q: "Kan ik één enkel stuk laten printen?",
+      a: "Ja, we printen vanaf één stuk en kunnen ook kleine series leveren.",
+    },
+    {
+      q: "Hoe sterk zijn 3D-geprinte onderdelen?",
+      a: "FDM-prints zijn stevig, maar afhankelijk van oriëntatie en materiaal. Ontwerp bepaalt de uiteindelijke sterkte.",
+    },
+    {
+      q: "Kunnen jullie mijn model verbeteren?",
+      a: "We voeren basis modelreparaties uit. Voor uitgebreid CAD-werk schakelen we partners in.",
     },
   ]
 
@@ -182,7 +268,7 @@ export default function Page() {
       <section className="px-6 pt-14 pb-10 sm:px-8 lg:px-12">
         <div className="mx-auto max-w-6xl">
           <Reveal>
-            <h1 className="bg-gradient-to-br from-slate-900 to-slate-700 bg-clip-text text-3xl font-bold tracking-tight text-transparent sm:text-4xl">
+            <h1 className="bg-gradient-to-br from-indigo-600 to-sky-500 bg-clip-text text-3xl font-bold tracking-tight text-transparent sm:text-4xl">
               Services
             </h1>
             <p className="mt-3 max-w-3xl text-slate-600">
@@ -214,7 +300,7 @@ export default function Page() {
             {services.map((s, i) => (
               <Reveal key={s.title} delay={i * 0.06}>
                 <GlassCard className="h-full p-6 transition-transform hover:-translate-y-1">
-                  <s.icon className="h-8 w-8 text-slate-900" aria-hidden />
+                  <s.icon className="h-8 w-8 text-indigo-600" aria-hidden />
                   <h3 className="mt-4 text-lg font-semibold text-slate-900">{s.title}</h3>
                   <p className="mt-2 text-sm text-slate-600">{s.description}</p>
                 </GlassCard>
@@ -237,7 +323,7 @@ export default function Page() {
             {useCases.map((u, i) => (
               <Reveal key={u.title} delay={i * 0.05}>
                 <GlassCard className="h-full p-6">
-                  <u.icon className="h-7 w-7 text-slate-900" aria-hidden />
+                  <u.icon className="h-7 w-7 text-indigo-600" aria-hidden />
                   <h3 className="mt-3 text-base font-semibold text-slate-900">{u.title}</h3>
                   <p className="mt-1 text-sm text-slate-600">{u.description}</p>
                 </GlassCard>
@@ -307,29 +393,16 @@ export default function Page() {
         </div>
       </section>
 
+      {/* CTA */}
+      <div className="px-6 pb-12 sm:px-8 lg:px-12">
+        <CtaBlock city="België" />
+      </div>
+
       {/* FAQ */}
       <section className="px-6 pb-20 sm:px-8 lg:px-12">
         <div className="mx-auto max-w-6xl">
           <Reveal>
-            <GlassCard className="p-6">
-              <h2 className="text-xl font-semibold tracking-tight text-slate-900">Veelgestelde vragen</h2>
-              <ul className="mt-3 space-y-3 text-slate-600">
-                {faq.map((f) => (
-                  <li key={f.q}>
-                    <h3 className="font-medium text-slate-900">{f.q}</h3>
-                    <p className="mt-1 text-sm">{f.a}</p>
-                  </li>
-                ))}
-              </ul>
-              <div className="mt-5">
-                <Link
-                  href="/contact"
-                  className="rounded-xl border border-white/20 bg-black px-5 py-3 text-sm font-semibold text-white hover:brightness-110"
-                >
-                  Offerte aanvragen
-                </Link>
-              </div>
-            </GlassCard>
+            <Faq city="België" items={faq} />
           </Reveal>
         </div>
       </section>


### PR DESCRIPTION
## Wat
- meer kleur op services-pagina (gradient, iconen, CTA)
- FAQ uitgebreid met extra 3D-printvragen met open/dicht animatie
- metadata geoptimaliseerd voor SEO

## Waarom
- visueel aantrekkelijker en beter vindbaar

## Testplan
- [ ] Build OK (`npm run build`) – faalt: Invalid segment configuration export detected
- [x] Lint OK (`npm run lint`)
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video


------
https://chatgpt.com/codex/tasks/task_b_68b8c92bb6c4833297ffd1d705023529