### PR TITLE
fix: allow dynamic slugs to fall back

### DIFF
--- a/app/(pages)/[slug]/page.tsx
+++ b/app/(pages)/[slug]/page.tsx
@@ -33,7 +33,6 @@ interface PageProps {
   params: { slug: string }
 }
 
-export const dynamicParams = false
 export const revalidate = 86_400 // 24u cache
 
 export function generateStaticParams() {


### PR DESCRIPTION
## Wat
- remove `dynamicParams = false` so unknown slugs use `notFound`

## Waarom
- ensure requests for non-existent locations render the 404 page

## Testplan
- [ ] Build OK (fails: Page "./(pages)/[slug]/page" missing param "[slug]" in `generateStaticParams()` with `output: export`)
- [x] Lint OK
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video


------
https://chatgpt.com/codex/tasks/task_b_68b98948495483328a1c36c88459d99e