### PR TITLE
fix: forward alt prop in TiltImage

### DIFF
--- a/components/TiltImage.tsx
+++ b/components/TiltImage.tsx
@@ -19,6 +19,7 @@ export default function TiltImage({
   className,
   intensity = 0.12,
   style,
+  alt,
   ...imgProps
 }: TiltImageProps) {
   const ref = useRef<HTMLDivElement>(null)
@@ -54,7 +55,7 @@ export default function TiltImage({
         ...style,
       }}
     >
-      <Image {...imgProps} />
+      <Image alt={alt} {...imgProps} />
     </div>
   )
 }


### PR DESCRIPTION
## Wat
- geef `alt` expliciet door in `TiltImage`

## Waarom
- voorkomt a11y lint waarschuwing

## Testplan
- [x] Build OK
- [x] Lint OK
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video


------
https://chatgpt.com/codex/tasks/task_b_68b98f39f8d48332aacd68ea46b158f3