### PR TITLE
fix: use https for contact API

### DIFF
--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -98,7 +98,10 @@ export default function ContactForm() {
       })
       files.forEach(f => form.append("files", f, f.name))
 
-      const res = await fetch("/api/contact", { method: "POST", body: form })
+      const res = await fetch(`${window.location.origin}/api/contact/`, {
+        method: "POST",
+        body: form,
+      })
       setStatus(res.ok ? "ok" : "error")
       if (res.ok) {
         setData({


### PR DESCRIPTION
## Wat
- force contactform API request over current origin (https)

## Waarom
- prevents mixed content error on live site

## Testplan
- [ ] Build OK
- [ ] Lint OK
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video


------
https://chatgpt.com/codex/tasks/task_b_68b998eab50083329de4df798255b3d5