### PR TITLE
fix: use phpmailer for contact form

### DIFF
--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -98,7 +98,8 @@ export default function ContactForm() {
       })
       files.forEach(f => form.append("files", f, f.name))
 
-      const res = await fetch(`${window.location.origin}/api/contact`, {
+      const endpoint = process.env.NEXT_PUBLIC_CONTACT_ENDPOINT ?? "/contact.php"
+      const res = await fetch(endpoint, {
         method: "POST",
         body: form,
       })

--- a/public/contact.php
+++ b/public/contact.php
@@ -1,6 +1,10 @@
 <?php
 // public/contact.php
-// Beperkte mail relay voor static hosting (Vimexx). Zorg dat max upload sizes in php.ini ok zijn.
+// Beperkte mail relay voor static hosting (Vimexx). Gebruik PHPMailer voor betrouwbare verzending via SMTP.
+
+require __DIR__ . '/../php/vendor/autoload.php';
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception;
 
 header("Content-Type: application/json; charset=utf-8");
 if ($_SERVER["REQUEST_METHOD"] !== "POST") {
@@ -71,51 +75,40 @@ if (!empty($_FILES["files"])) {
   }
 }
 
-$to = "info@x3dprints.be";
-$subject = "[Contact] ".($type === "business" ? "Bedrijf" : "Particulier")." — ".$name;
+try {
+  $mail = new PHPMailer(true);
+  $mail->setFrom('no-reply@x3dprints.be', 'X3DPrints');
+  $mail->addAddress('info@x3dprints.be');
+  $mail->addReplyTo($email, $name);
+  $mail->isHTML(true);
+  $mail->Subject = '[Contact] ' . ($type === 'business' ? 'Bedrijf' : 'Particulier') . ' — ' . $name;
 
-// Bouw multipart mail met attachments
-$boundary = md5(uniqid(time(), true));
-$headers = "From: X3DPrints <no-reply@x3dprints.be>\r\n";
-$headers .= "Reply-To: $email\r\n";
-$headers .= "MIME-Version: 1.0\r\n";
-$headers .= "Content-Type: multipart/mixed; boundary=\"$boundary\"\r\n";
+  $body = '<h2>Nieuwe contactaanvraag</h2>';
+  $body .= '<ul>';
+  $body .= '<li><strong>Naam:</strong> ' . htmlspecialchars($name) . '</li>';
+  $body .= '<li><strong>E-mail:</strong> ' . htmlspecialchars($email) . '</li>';
+  $body .= '<li><strong>Type:</strong> ' . htmlspecialchars($type) . '</li>';
+  if ($company) $body .= '<li><strong>Bedrijf:</strong> ' . htmlspecialchars($company) . '</li>';
+  if ($vat) $body .= '<li><strong>BTW:</strong> ' . htmlspecialchars($vat) . '</li>';
+  if ($address) $body .= '<li><strong>Adres:</strong> ' . htmlspecialchars($address) . '</li>';
+  if ($quantity) $body .= '<li><strong>Aantal:</strong> ' . htmlspecialchars($quantity) . '</li>';
+  if ($material) $body .= '<li><strong>Materiaal:</strong> ' . htmlspecialchars($material) . '</li>';
+  $body .= '</ul>';
+  $body .= '<p><strong>Bericht:</strong></p>';
+  $body .= '<pre style="white-space:pre-wrap;font-family:ui-monospace,Menlo,monospace">' . htmlspecialchars($message) . '</pre>';
+  $mail->Body = $body;
 
-$body  = "--$boundary\r\n";
-$body .= "Content-Type: text/html; charset=\"UTF-8\"\r\n\r\n";
-$body .= "<h2>Nieuwe contactaanvraag</h2>";
-$body .= "<ul>";
-$body .= "<li><strong>Naam:</strong> ".htmlspecialchars($name)."</li>";
-$body .= "<li><strong>E-mail:</strong> ".htmlspecialchars($email)."</li>";
-$body .= "<li><strong>Type:</strong> ".htmlspecialchars($type)."</li>";
-if ($company) $body .= "<li><strong>Bedrijf:</strong> ".htmlspecialchars($company)."</li>";
-if ($vat) $body .= "<li><strong>BTW:</strong> ".htmlspecialchars($vat)."</li>";
-if ($address) $body .= "<li><strong>Adres:</strong> ".htmlspecialchars($address)."</li>";
-if ($quantity) $body .= "<li><strong>Aantal:</strong> ".htmlspecialchars($quantity)."</li>";
-if ($material) $body .= "<li><strong>Materiaal:</strong> ".htmlspecialchars($material)."</li>";
-$body .= "</ul>";
-$body .= "<p><strong>Bericht:</strong></p>";
-$body .= "<pre style=\"white-space:pre-wrap;font-family:ui-monospace,Menlo,monospace\">".htmlspecialchars($message)."</pre>";
-
-if (!empty($_FILES["files"])) {
-  for ($i=0; $i<count($_FILES["files"]["name"]); $i++) {
-    $tmp = $_FILES["files"]["tmp_name"][$i];
-    $filename = sanitize_filename($_FILES["files"]["name"][$i]);
-    $data = chunk_split(base64_encode(file_get_contents($tmp)));
-    $ctype = $_FILES["files"]["type"][$i] ?: "application/octet-stream";
-    $body .= "\r\n--$boundary\r\n";
-    $body .= "Content-Type: $ctype; name=\"$filename\"\r\n";
-    $body .= "Content-Transfer-Encoding: base64\r\n";
-    $body .= "Content-Disposition: attachment; filename=\"$filename\"\r\n\r\n";
-    $body .= $data . "\r\n";
+  if (!empty($_FILES['files'])) {
+    for ($i=0; $i<count($_FILES['files']['name']); $i++) {
+      $tmp = $_FILES['files']['tmp_name'][$i];
+      $filename = sanitize_filename($_FILES['files']['name'][$i]);
+      $mail->addAttachment($tmp, $filename);
+    }
   }
-}
-$body .= "--$boundary--";
 
-$ok = mail($to, "=?UTF-8?B?".base64_encode($subject)."?=", $body, $headers);
-if ($ok) {
-  echo json_encode(["ok"=>true]);
-} else {
+  $mail->send();
+  echo json_encode(['ok' => true]);
+} catch (Exception $e) {
   http_response_code(500);
-  echo json_encode(["ok"=>false,"error"=>"Mail verzenden mislukt (server)."]);
+  echo json_encode(['ok' => false, 'error' => 'Mail verzenden mislukt (server).']);
 }


### PR DESCRIPTION
## Wat
- schakel over op PHPMailer voor PHP-contactendpoint
- maak formulier-endpoint configureerbaar en standaard op `contact.php`

## Waarom
- Node API endpoints werken niet op statische Apache-hosting

## Testplan
- [ ] Build OK
- [ ] Lint OK
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video


------
https://chatgpt.com/codex/tasks/task_b_68b9c74dd5048332a1a5a59492e98c3b