### PR TITLE
feat: reorganize footer and local pages

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,7 +2,7 @@
 import Link from "next/link"
 import Image from "next/image"
 import Container from "./Container"
-import { getAllLocationSlugs, getLocationBySlug } from "@/lib/locations"
+import FooterLocations from "./FooterLocations"
 
 const socials = [
   { href: "https://www.linkedin.com/company/x3dprints", label: "LinkedIn", icon: "linkedin" },
@@ -34,32 +34,6 @@ function SocialIcon({ type, className }: { type: string; className?: string }) {
 }
 
 export default function Footer() {
-  // Bouw locaties op (server component), sorteer alfabetisch
-  const slugs = getAllLocationSlugs()
-  const locations = slugs
-    .map((slug) => ({ slug, city: getLocationBySlug(slug)?.city ?? slug }))
-    .sort((a, b) => a.city.localeCompare(b.city, "nl"))
-
-  const topVisible = locations.slice(0, 12)
-  const rest = locations.slice(12)
-
-  // Groepeer rest op initiaal (A, B, C...)
-  const grouped: Record<string, { slug: string; city: string }[]> = {}
-  for (const loc of rest) {
-    const k = (loc.city?.[0] ?? "#").toUpperCase()
-    if (!grouped[k]) grouped[k] = []
-    grouped[k].push(loc)
-  }
-  const letters = Object.keys(grouped).sort()
-
-  // JSON-LD voor ItemList (cap op 50)
-  const itemList = locations.slice(0, 50).map((loc, i) => ({
-    "@type": "ListItem",
-    position: i + 1,
-    url: `https://www.x3dprints.be/${loc.slug}`,
-    name: `3D printen in ${loc.city}`,
-  }))
-
   return (
     <footer className="relative mt-24">
       {/* top gradient hairline */}
@@ -87,7 +61,7 @@ export default function Footer() {
 
       {/* main footer */}
       <div className="mt-10 border-t bg-white/60 backdrop-blur">
-        <Container className="grid gap-10 py-12 text-sm text-slate-600 md:grid-cols-4">
+        <Container className="grid gap-10 py-12 text-sm text-slate-600 md:grid-cols-5">
           {/* brand */}
           <div className="md:col-span-2">
             <Link href="/" className="inline-flex items-center gap-3">
@@ -142,95 +116,10 @@ export default function Footer() {
               <li><Link href="/sitemap.xml" className="hover:text-slate-900">Sitemap</Link></li>
             </ul>
           </div>
+
+          {/* lokale pagina's */}
+          <FooterLocations />
         </Container>
-
-        {/* LOKALE PAGINA'S: volle-breedte band onder de hoofdfooter */}
-        <div className="border-t bg-white/70">
-          <Container className="py-10">
-            <div className="flex items-center justify-between gap-4">
-              <div>
-                <h3 className="text-sm font-semibold tracking-tight text-slate-900">Lokale pagina’s</h3>
-                <p className="mt-1 text-xs text-slate-600">
-                  Snelle toegang per regio.
-                </p>
-              </div>
-              <Link
-                href="/locaties"
-                className="rounded-full border border-white/30 bg-white/70 px-3 py-1.5 text-xs text-slate-700 backdrop-blur transition hover:bg-white hover:text-slate-900"
-              >
-                Alle locaties pagina
-              </Link>
-            </div>
-
-            {/* Top 12 als pills */}
-            {topVisible.length > 0 && (
-              <ul className="mt-4 flex flex-wrap gap-2">
-                {topVisible.map((loc) => (
-                  <li key={loc.slug}>
-                    <Link
-                      href={`/${loc.slug}`}
-                      className="rounded-full border border-white/30 bg-white/70 px-3 py-1.5 text-xs text-slate-700 backdrop-blur transition hover:bg-white hover:text-slate-900"
-                    >
-                      3D printen in {loc.city}
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            )}
-
-            {/* Uitklapbare mega-lijst op alfabet, voor grote aantallen */}
-            {rest.length > 0 && (
-              <details className="group mt-5">
-                <summary className="inline-flex cursor-pointer select-none items-center gap-2 rounded-full border border-white/30 bg-white/60 px-3 py-1.5 text-xs font-medium text-slate-700 backdrop-blur transition hover:bg-white">
-                  Toon alle locaties
-                  <svg width="14" height="14" viewBox="0 0 24 24" className="opacity-70 transition group-open:rotate-180">
-                    <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="1.8" fill="none" strokeLinecap="round" />
-                  </svg>
-                </summary>
-
-                <div className="mt-4 space-y-6">
-                  {letters.map((letter) => (
-                    <div key={letter}>
-                      <div className="mb-2 text-xs font-semibold tracking-wider text-slate-500">{letter}</div>
-                      <ul
-                        className="
-                          grid grid-cols-1 gap-2
-                          sm:grid-cols-2
-                          md:grid-cols-3
-                          lg:grid-cols-4
-                        "
-                      >
-                        {grouped[letter].map((loc) => (
-                          <li key={loc.slug}>
-                            <Link
-                              href={`/${loc.slug}`}
-                              className="inline-block rounded-full border border-white/30 bg-white/60 px-3 py-1.5 text-xs text-slate-700 backdrop-blur transition hover:bg-white hover:text-slate-900"
-                            >
-                              3D printen in {loc.city}
-                            </Link>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  ))}
-                </div>
-              </details>
-            )}
-
-            {/* JSON-LD ItemList voor crawlers */}
-            <script
-              type="application/ld+json"
-              // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{
-                __html: JSON.stringify({
-                  "@context": "https://schema.org",
-                  "@type": "ItemList",
-                  itemListElement: itemList,
-                }),
-              }}
-            />
-          </Container>
-        </div>
 
         {/* bottom bar */}
         <div className="border-t">

--- a/components/FooterLocations.tsx
+++ b/components/FooterLocations.tsx
@@ -1,23 +1,38 @@
-// components/FooterLocations.tsx
+"use client"
+
+import { useMemo, useState } from "react"
 import Link from "next/link"
 import { getAllLocationSlugs, getLocationBySlug } from "@/lib/locations"
 
 type Props = {
   title?: string
-  maxVisible?: number // aantal directe links voordat "Alle locaties" verschijnt
+  initial?: number // aantal items zichtbaar voor "Toon meer"
 }
 
-export default function FooterLocations({ title = "Lokale pagina’s", maxVisible = 12 }: Props) {
+export default function FooterLocations({ title = "Lokale pagina\u2019s", initial = 12 }: Props) {
   const slugs = getAllLocationSlugs()
-  const locations = slugs
-    .map((slug) => ({ slug, city: getLocationBySlug(slug)?.city ?? slug }))
-    .sort((a, b) => a.city.localeCompare(b.city, "nl"))
+  const locations = useMemo(
+    () =>
+      slugs
+        .map((slug) => ({ slug, city: getLocationBySlug(slug)?.city ?? slug }))
+        .sort((a, b) => a.city.localeCompare(b.city, "nl")),
+    [slugs]
+  )
 
-  const visible = locations.slice(0, maxVisible)
-  const hidden = locations.slice(maxVisible)
+  const [query, setQuery] = useState("")
+  const [letter, setLetter] = useState<string>("")
+  const filtered = locations.filter((loc) => {
+    const matchQuery = loc.city.toLowerCase().includes(query.toLowerCase())
+    const matchLetter = letter ? loc.city[0].toUpperCase() === letter : true
+    return matchQuery && matchLetter
+  })
 
-  // JSON-LD ItemList (beperk tot 50, dat is zat)
-  const itemList = locations.slice(0, 50).map((loc, i) => ({
+  const [showAll, setShowAll] = useState(false)
+  const visible = showAll ? filtered : filtered.slice(0, initial)
+
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("")
+
+  const itemList = filtered.slice(0, 50).map((loc, i) => ({
     "@type": "ListItem",
     position: i + 1,
     url: `https://www.x3dprints.be/${loc.slug}`,
@@ -28,58 +43,66 @@ export default function FooterLocations({ title = "Lokale pagina’s", maxVisibl
     <div className="mt-2">
       <div className="font-semibold text-slate-900">{title}</div>
 
-      {/* zichtbare set als glass-pills */}
-      <ul className="mt-3 flex flex-wrap gap-2">
+      <input
+        type="text"
+        aria-label="Zoek stad of gemeente"
+        placeholder="Zoek stad of gemeente..."
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        className="mt-3 w-full rounded-xl border border-white/30 bg-white/70 px-3 py-2 text-xs text-slate-700 placeholder:text-slate-400 backdrop-blur transition focus:border-teal-300 focus:outline-none focus:ring-2 focus:ring-teal-300"
+      />
+
+      <div className="mt-3 flex flex-wrap gap-1">
+        <button
+          type="button"
+          onClick={() => setLetter("")}
+          className={`rounded-md px-2 py-1 text-xs transition ${
+            letter === "" ? "bg-teal-500 text-white" : "text-slate-700 hover:bg-white/60"
+          }`}
+        >
+          Alle
+        </button>
+        {alphabet.map((l) => (
+          <button
+            key={l}
+            type="button"
+            onClick={() => setLetter(l)}
+            className={`rounded-md px-2 py-1 text-xs transition ${
+              letter === l ? "bg-teal-500 text-white" : "text-slate-700 hover:bg-white/60"
+            }`}
+          >
+            {l}
+          </button>
+        ))}
+      </div>
+
+      <p className="mt-3 text-xs text-slate-500">{filtered.length} locaties gevonden.</p>
+
+      <ul className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
         {visible.map((loc) => (
           <li key={loc.slug}>
             <Link
               href={`/${loc.slug}`}
-              className="rounded-full border border-white/30 bg-white/70 px-3 py-1.5 text-xs text-slate-700 backdrop-blur transition hover:bg-white hover:text-slate-900"
+              className="block rounded-xl border border-white/30 bg-white/70 px-3 py-2 text-xs text-slate-700 backdrop-blur transition hover:bg-white hover:text-slate-900"
             >
-              3D printen in {loc.city}
+              {loc.city}
             </Link>
           </li>
         ))}
       </ul>
 
-      {/* uitklap voor alle overige locaties; crawlable en a11y-oké */}
-      {hidden.length > 0 && (
-        <details className="group mt-3">
-          <summary
-            className="inline-flex cursor-pointer select-none items-center gap-2 rounded-full border border-white/30 bg-white/60 px-3 py-1.5 text-xs font-medium text-slate-700 backdrop-blur transition hover:bg-white"
-            aria-label="Toon alle locaties"
-          >
-            Alle locaties
-            <svg width="14" height="14" viewBox="0 0 24 24" className="opacity-70 transition group-open:rotate-180">
-              <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="1.8" fill="none" strokeLinecap="round" />
-            </svg>
-          </summary>
-
-          <ul
-            className="
-              mt-3 grid grid-cols-1 gap-2
-              sm:grid-cols-2
-              lg:grid-cols-3
-            "
-          >
-            {hidden.map((loc) => (
-              <li key={loc.slug}>
-                <Link
-                  href={`/${loc.slug}`}
-                  className="inline-block rounded-full border border-white/30 bg-white/60 px-3 py-1.5 text-xs text-slate-700 backdrop-blur transition hover:bg-white hover:text-slate-900"
-                >
-                  3D printen in {loc.city}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </details>
+      {filtered.length > initial && !showAll && (
+        <button
+          type="button"
+          onClick={() => setShowAll(true)}
+          className="mt-4 w-full rounded-xl border border-slate-200/70 bg-[linear-gradient(90deg,#6366f1,45%,#22d3ee)] px-3 py-2 text-xs font-semibold text-white shadow-[0_8px_24px_rgba(99,102,241,.35)] transition hover:brightness-110"
+        >
+          Toon meer locaties
+        </button>
       )}
 
-      {/* JSON-LD ItemList */}
       <script
         type="application/ld+json"
-        // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{
           __html: JSON.stringify({
             "@context": "https://schema.org",
@@ -91,3 +114,4 @@ export default function FooterLocations({ title = "Lokale pagina’s", maxVisibl
     </div>
   )
 }
+


### PR DESCRIPTION
## Wat
- herstructureer footer met kolom voor lokale pagina's
- alfabetische groepingsstructuur voor resterende locaties
- zoek- en letterfilter voor alle locaties in footer

## Waarom
- logischer overzicht en snellere toegang tot lokale landingspagina's

## Testplan
- [x] Build OK
- [x] Lint OK
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video


------
https://chatgpt.com/codex/tasks/task_b_68badaee542483329eb8468d46e54c23