### PR TITLE
Add cookie consent banner and analytics loader

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,11 @@ import { SITE } from "@/lib/seo"
 import Header from "@/components/Header"
 import Footer from "@/components/Footer"
 import ScrollProgress from "@/components/ScrollProgress"
+import CookieBanner from "@/components/CookieBanner"
+import AnalyticsConsent from "@/components/AnalyticsConsent"
 import { cn } from "@/lib/utils";
+
+const googleSiteVerification = process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE.url),
@@ -32,6 +36,11 @@ export const metadata: Metadata = {
     images: [SITE.ogImage],
   },
   icons: { icon: "/favicon.ico" },
+  other: googleSiteVerification
+    ? {
+        "google-site-verification": googleSiteVerification,
+      }
+    : undefined,
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -66,6 +75,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <Header />
         <main className="flex-1">{children}</main>
         <Footer />
+        <CookieBanner />
+        <AnalyticsConsent />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}

--- a/components/AnalyticsConsent.tsx
+++ b/components/AnalyticsConsent.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Script from "next/script"
+import { CookieConsentValue, onConsentChange, readStoredConsent } from "@/lib/cookie-consent"
+
+const GA_TRACKING_ID = process.env.NEXT_PUBLIC_GA_ID
+
+export default function AnalyticsConsent() {
+  const [consent, setConsent] = useState<CookieConsentValue | null>(null)
+  const canLoadAnalytics = consent === "granted" && typeof GA_TRACKING_ID === "string" && GA_TRACKING_ID.length > 0
+
+  useEffect(() => {
+    const initial = readStoredConsent()
+    if (initial) {
+      setConsent(initial)
+    }
+
+    const unsubscribe = onConsentChange((value) => {
+      setConsent(value)
+    })
+
+    return () => {
+      unsubscribe()
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof GA_TRACKING_ID !== "string" || GA_TRACKING_ID.length === 0) return
+    if (consent === "granted") {
+      ;(window as typeof window & { [key: string]: unknown })[`ga-disable-${GA_TRACKING_ID}`] = false
+    } else {
+      ;(window as typeof window & { [key: string]: unknown })[`ga-disable-${GA_TRACKING_ID}`] = true
+    }
+  }, [consent])
+
+  if (!canLoadAnalytics) {
+    return null
+  }
+
+  return (
+    <>
+      <Script id="ga-loader" src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`} strategy="afterInteractive" />
+      <Script id="ga-config" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GA_TRACKING_ID}', { anonymize_ip: true });
+        `}
+      </Script>
+    </>
+  )
+}

--- a/components/CookieBanner.tsx
+++ b/components/CookieBanner.tsx
@@ -1,0 +1,120 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import Link from "next/link"
+import { cn } from "@/lib/utils"
+import {
+  CookieConsentValue,
+  REQUEST_BANNER_EVENT,
+  onConsentChange,
+  persistConsent,
+  readStoredConsent,
+} from "@/lib/cookie-consent"
+
+export default function CookieBanner() {
+  const [open, setOpen] = useState(false)
+  const [lastChoice, setLastChoice] = useState<CookieConsentValue | null>(null)
+  const dialogRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const existing = readStoredConsent()
+    if (!existing) {
+      setOpen(true)
+    } else {
+      setLastChoice(existing)
+    }
+  }, [])
+
+  useEffect(() => {
+    const handler = () => {
+      const current = readStoredConsent()
+      setLastChoice(current)
+      setOpen(true)
+      setTimeout(() => {
+        dialogRef.current?.focus()
+      }, 0)
+    }
+
+    window.addEventListener(REQUEST_BANNER_EVENT, handler)
+    return () => window.removeEventListener(REQUEST_BANNER_EVENT, handler)
+  }, [])
+
+  useEffect(() => {
+    const unsubscribe = onConsentChange((value) => {
+      setLastChoice(value)
+    })
+
+    return () => {
+      unsubscribe()
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+    const timer = setTimeout(() => {
+      dialogRef.current?.focus()
+    }, 50)
+    return () => clearTimeout(timer)
+  }, [open])
+
+  const handleChoice = (value: CookieConsentValue) => {
+    persistConsent(value)
+    setLastChoice(value)
+    setOpen(false)
+  }
+
+  if (!open) return null
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-4 z-[80] flex justify-center px-4 sm:px-6">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cookie-banner-title"
+        tabIndex={-1}
+        className={cn(
+          "pointer-events-auto w-full max-w-3xl rounded-2xl border border-slate-200/70 bg-white/90 shadow-xl backdrop-blur",
+          "ring-1 ring-black/5",
+        )}
+      >
+        <div className="grid gap-4 p-5 sm:grid-cols-[1fr_auto] sm:items-center sm:gap-6 sm:p-6">
+          <div>
+            <p id="cookie-banner-title" className="text-sm font-semibold tracking-tight text-slate-900">
+              Cookies voor analyse
+            </p>
+            <p className="mt-2 text-sm leading-relaxed text-slate-600">
+              We gebruiken Google Analytics om de prestaties van onze website te meten. We plaatsen alleen analytische cookies
+              nadat je hiervoor toestemming hebt gegeven. Lees meer in ons{" "}
+              <Link href="/privacy" className="font-medium text-slate-900 underline-offset-2 hover:underline">
+                privacybeleid
+              </Link>
+              .
+            </p>
+            {lastChoice && (
+              <p className="mt-2 text-xs text-slate-500">
+                Huidige keuze: {lastChoice === "granted" ? "cookies toegestaan" : "cookies geweigerd"}.
+              </p>
+            )}
+          </div>
+          <div className="flex flex-col gap-2 sm:justify-self-end">
+            <button
+              type="button"
+              onClick={() => handleChoice("denied")}
+              className="inline-flex items-center justify-center rounded-xl border border-slate-200/70 bg-white/80 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-white"
+            >
+              Weigeren
+            </button>
+            <button
+              type="button"
+              onClick={() => handleChoice("granted")}
+              className="inline-flex items-center justify-center rounded-xl border border-slate-200/70 bg-[linear-gradient(90deg,#6366f1,45%,#22d3ee)] px-4 py-2 text-sm font-semibold text-white shadow-[0_8px_24px_rgba(99,102,241,.35)] transition hover:brightness-110"
+            >
+              Accepteren
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/CookieSettingsButton.tsx
+++ b/components/CookieSettingsButton.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { requestConsentBanner } from "@/lib/cookie-consent"
+import { cn } from "@/lib/utils"
+
+interface CookieSettingsButtonProps {
+  className?: string
+}
+
+export default function CookieSettingsButton({ className }: CookieSettingsButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={requestConsentBanner}
+      className={cn(
+        "inline-flex items-center gap-2 rounded-xl border border-transparent px-3 py-1.5 text-xs font-semibold text-slate-600 transition hover:text-slate-900",
+        className,
+      )}
+    >
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden className="text-slate-500">
+        <path
+          d="M12 15.5a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7Zm7.4-3.5c0-.4 0-.7-.1-1l1.6-1.2a.7.7 0 0 0 .2-.9l-1.5-2.6a.7.7 0 0 0-.8-.3l-1.8.7c-.5-.4-1-.7-1.5-.9L15 2.6a.7.7 0 0 0-.7-.6h-3a.7.7 0 0 0-.6.5l-.4 2.2c-.6.2-1.1.5-1.6.9l-2-.8a.7.7 0 0 0-.8.3L4.4 7.7a.7.7 0 0 0 .1.9l1.7 1.3v1.2L4.5 12.1a.7.7 0 0 0-.2.9l1.5 2.6c.2.3.5.4.8.3l1.9-.7c.5.4 1 .7 1.6.9l.4 2.2c.1.3.3.5.6.5h3a.7.7 0 0 0 .7-.6l.4-2.2c.5-.2 1-.5 1.5-.9l1.8.7c.3.1.6 0 .8-.3l1.5-2.6a.7.7 0 0 0-.2-.9l-1.5-1.1a6 6 0 0 0 .1-1Zm-2 0a5.4 5.4 0 1 1-10.8 0 5.4 5.4 0 0 1 10.8 0Z"
+          fill="currentColor"
+        />
+      </svg>
+      Cookie-instellingen
+    </button>
+  )
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import Image from "next/image"
 import Container from "./Container"
 import FooterLocations from "./FooterLocations"
+import CookieSettingsButton from "./CookieSettingsButton"
 
 const socials = [
   { href: "https://www.linkedin.com/company/x3dprints", label: "LinkedIn", icon: "linkedin" },
@@ -129,12 +130,21 @@ export default function Footer() {
         <div className="border-t">
           <Container className="flex flex-col items-center justify-between gap-3 py-6 text-xs text-slate-500 md:flex-row">
             <p>© {new Date().getFullYear()} X3DPrints. Alle rechten voorbehouden.</p>
-            <p className="text-slate-400">
-              Gemaakt door{" "}
-              <Link href="https://www.xinudesign.be" className="hover:text-slate-900" target="_blank" rel="noopener noreferrer">
-                Xinudesign
-              </Link>.
-            </p>
+            <div className="flex flex-col items-center gap-2 md:flex-row md:gap-4">
+              <CookieSettingsButton className="text-slate-500 hover:text-slate-900" />
+              <p className="text-slate-400">
+                Gemaakt door{" "}
+                <Link
+                  href="https://www.xinudesign.be"
+                  className="hover:text-slate-900"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Xinudesign
+                </Link>
+                .
+              </p>
+            </div>
           </Container>
         </div>
       </div>

--- a/lib/cookie-consent.ts
+++ b/lib/cookie-consent.ts
@@ -1,0 +1,80 @@
+export type CookieConsentValue = "granted" | "denied"
+
+const STORAGE_KEY = "x3dprints:cookie-consent"
+const COOKIE_NAME = "x3dprints-cookie-consent"
+export const CONSENT_EVENT = "x3dprints:cookie-consent-change"
+export const REQUEST_BANNER_EVENT = "x3dprints:cookie-consent-open"
+
+function safeWindow(): Window | undefined {
+  if (typeof window === "undefined") return undefined
+  return window
+}
+
+export function readStoredConsent(): CookieConsentValue | null {
+  const w = safeWindow()
+  if (!w) return null
+
+  try {
+    const fromStorage = w.localStorage.getItem(STORAGE_KEY) as CookieConsentValue | null
+    if (fromStorage === "granted" || fromStorage === "denied") {
+      return fromStorage
+    }
+  } catch {
+    // localStorage might be blocked; ignore and fall back to cookies
+  }
+
+  if (typeof document === "undefined") return null
+
+  const cookie = document.cookie
+    .split(";")
+    .map((entry) => entry.trim())
+    .find((entry) => entry.startsWith(`${COOKIE_NAME}=`))
+
+  if (!cookie) return null
+
+  const value = cookie.split("=")[1]
+  if (value === "granted" || value === "denied") {
+    return value
+  }
+
+  return null
+}
+
+export function persistConsent(value: CookieConsentValue) {
+  const w = safeWindow()
+  if (!w) return
+
+  try {
+    w.localStorage.setItem(STORAGE_KEY, value)
+  } catch {
+    // Ignore storage errors (e.g. Safari private mode)
+  }
+
+  const maxAge = 60 * 60 * 24 * 180 // 180 days
+  if (typeof document !== "undefined") {
+    document.cookie = `${COOKIE_NAME}=${value};path=/;max-age=${maxAge};SameSite=Lax`
+  }
+
+  w.dispatchEvent(new CustomEvent<CookieConsentValue>(CONSENT_EVENT, { detail: value }))
+}
+
+export function requestConsentBanner() {
+  const w = safeWindow()
+  if (!w) return
+  w.dispatchEvent(new Event(REQUEST_BANNER_EVENT))
+}
+
+export function onConsentChange(callback: (value: CookieConsentValue) => void) {
+  const w = safeWindow()
+  if (!w) return () => {}
+
+  const handler = (event: Event) => {
+    const detail = (event as CustomEvent<CookieConsentValue>).detail
+    if (detail === "granted" || detail === "denied") {
+      callback(detail)
+    }
+  }
+
+  w.addEventListener(CONSENT_EVENT, handler as EventListener)
+  return () => w.removeEventListener(CONSENT_EVENT, handler as EventListener)
+}


### PR DESCRIPTION
## Wat
- Voeg een cookiebanner toe in X3DPrints-stijl inclusief keuze voor analytische cookies en link naar privacybeleid.
- Laad Google Analytics alleen na toestemming en voeg cookie-instellingen-knop toe in de footer.
- Voorzie metadata van een optionele Google Search Console verificatietag via omgevingsvariabele.

## Waarom
- Nodig om analytische cookies privacyvriendelijk te activeren en beheerbaar te maken voor bezoekers.
- Google Analytics en Search Console vereisen toestemming/verification alvorens te meten.

## Testplan
- [ ] Build OK
- [x] Lint OK (npm run lint — bestaande waarschuwingen in legacy bestanden)
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6917c722f5d08332a8a594d9f727e30a)