### PR TITLE
Add Google Analytics tag behind consent gate

### DIFF
--- a/components/AnalyticsConsent.tsx
+++ b/components/AnalyticsConsent.tsx
@@ -4,11 +4,15 @@ import { useEffect, useState } from "react"
 import Script from "next/script"
 import { CookieConsentValue, onConsentChange, readStoredConsent } from "@/lib/cookie-consent"
 
-const GA_TRACKING_ID = process.env.NEXT_PUBLIC_GA_ID
+const DEFAULT_GA_ID = "G-QPQ7LDMSRV"
+const envTrackingId = process.env.NEXT_PUBLIC_GA_ID
+const GA_TRACKING_ID =
+  typeof envTrackingId === "string" && envTrackingId.trim().length > 0 ? envTrackingId.trim() : DEFAULT_GA_ID
 
 export default function AnalyticsConsent() {
   const [consent, setConsent] = useState<CookieConsentValue | null>(null)
-  const canLoadAnalytics = consent === "granted" && typeof GA_TRACKING_ID === "string" && GA_TRACKING_ID.length > 0
+  const hasTrackingId = GA_TRACKING_ID.length > 0
+  const canLoadAnalytics = consent === "granted" && hasTrackingId
 
   useEffect(() => {
     const initial = readStoredConsent()
@@ -26,13 +30,17 @@ export default function AnalyticsConsent() {
   }, [])
 
   useEffect(() => {
-    if (typeof GA_TRACKING_ID !== "string" || GA_TRACKING_ID.length === 0) return
-    if (consent === "granted") {
-      ;(window as typeof window & { [key: string]: unknown })[`ga-disable-${GA_TRACKING_ID}`] = false
-    } else {
-      ;(window as typeof window & { [key: string]: unknown })[`ga-disable-${GA_TRACKING_ID}`] = true
+    if (!hasTrackingId) return
+    const disableKey = `ga-disable-${GA_TRACKING_ID}`
+    ;(window as typeof window & { [key: string]: unknown })[disableKey] = consent === "granted" ? false : true
+  }, [consent, hasTrackingId])
+
+  if (!hasTrackingId) {
+    if (process.env.NODE_ENV === "development") {
+      console.warn("Google Analytics tracking ID ontbreekt: stel NEXT_PUBLIC_GA_ID in of gebruik de default.")
     }
-  }, [consent])
+    return null
+  }
 
   if (!canLoadAnalytics) {
     return null


### PR DESCRIPTION
## Wat
- laad de Google Analytics tag met tracking ID `G-QPQ7LDMSRV` zodra er toestemming is
- voeg een waarschuwing toe in development wanneer er geen tracking ID beschikbaar is

## Waarom
- om Analytics te activeren op elke pagina zonder bijkomende code per pagina

## Testplan
- [ ] Build OK
- [ ] Lint OK (warnings over bestaande ongebruikte imports/disable directives)
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video
- n.v.t.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6917cc0a39d48332b0ce676e2ac42ecb)