### PR TITLE
Add interactive 3D viewer page

### DIFF
--- a/app/(pages)/viewer/page.tsx
+++ b/app/(pages)/viewer/page.tsx
@@ -1,0 +1,159 @@
+import dynamic from "next/dynamic"
+import type { Metadata } from "next"
+
+import Container from "@/components/Container"
+import Reveal from "@/components/Reveal"
+import GlassCard from "@/components/GlassCard"
+
+const ModelViewer = dynamic(() => import("@/components/ModelViewer"), {
+  ssr: false,
+  loading: () => (
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+      <div className="aspect-[4/3] w-full animate-pulse rounded-3xl bg-gradient-to-br from-slate-900/80 via-slate-900/40 to-slate-900/80" />
+      <div className="grid gap-4">
+        <div className="h-32 rounded-3xl bg-white/40" />
+        <div className="h-24 rounded-3xl bg-white/30" />
+      </div>
+    </div>
+  ),
+})
+
+export const metadata: Metadata = {
+  title: "Realtime 3D Model Viewer voor STL's | X3DPrints",
+  description:
+    "Upload een STL, OBJ of GLB en bekijk meteen hoe je 3D print oogt. Alles gebeurt lokaal in je browser met validatie, privacy en snelle interactie.",
+  alternates: { canonical: "https://www.x3dprints.be/viewer" },
+  openGraph: {
+    title: "Realtime 3D Model Viewer voor STL's",
+    description:
+      "Upload een STL, OBJ of GLB en bekijk meteen hoe je print eruitziet. Privacyvriendelijk, performant en in de stijl van X3DPrints.",
+    url: "https://www.x3dprints.be/viewer",
+    images: [{ url: "/images/og-home.jpg", width: 1200, height: 630 }],
+    locale: "nl_BE",
+    siteName: "X3DPrints",
+  },
+  twitter: { card: "summary_large_image" },
+}
+
+export default function Page() {
+  const bullets = [
+    "WebGL-viewer met orbit controls en auto-rotate (uitschakelbaar)",
+    "On-device parsing met STL/OBJ/GLB-ondersteuning tot 15 MB",
+    "Mesh stats voor snelle sanity-checks vóór je offerte-aanvraag",
+  ]
+
+  const highlights = [
+    {
+      title: "Performance voorop",
+      description:
+        "Adaptive pixel density, orbit damping en lightweight shadows houden de viewer soepel — ook op mobiel.",
+    },
+    {
+      title: "Validatie zonder stress",
+      description:
+        "We valideren bestandsgrootte en formaten direct. Fouten verschijnen met duidelijke uitleg en advies.",
+    },
+    {
+      title: "Privacy by design",
+      description:
+        "Geen upload naar servers: het model leeft enkel in de browser en verdwijnt zodra je refresh of sluit.",
+    },
+  ]
+
+  const workflow = [
+    {
+      step: "1. Upload of drop",
+      copy: "Sleep je STL, OBJ of GLB in de dropzone. We accepteren tot 15 MB, ideaal voor snelle previews.",
+    },
+    {
+      step: "2. Interpreteer de mesh",
+      copy: "Draai, zoom en check vertex/face-count. Zo weet je meteen of het model klaar is voor productie.",
+    },
+    {
+      step: "3. Deel feedback",
+      copy: "Tevreden? Stuur het bestand mee via het offerteformulier voor prijs en planning op maat.",
+    },
+  ]
+
+  return (
+    <main className="relative overflow-hidden">
+      <div aria-hidden className="pointer-events-none absolute inset-x-0 top-[-30%] h-[480px] bg-[radial-gradient(circle_at_top,#1e3a8a33,transparent_65%)]" />
+      <div aria-hidden className="pointer-events-none absolute inset-y-0 right-[-40%] w-[560px] rounded-full bg-[radial-gradient(circle,#0ea5e944,transparent_70%)] blur-3xl" />
+
+      <section className="py-20 sm:py-24">
+        <Container className="relative">
+          <Reveal className="max-w-3xl">
+            <p className="mb-4 inline-flex items-center gap-2 rounded-full border border-slate-200/70 bg-white/70 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600">
+              <span className="h-2 w-2 rounded-full bg-emerald-400" aria-hidden /> Nieuw: 3D preview
+            </p>
+            <h1 className="text-4xl font-semibold tracking-tight text-slate-900 sm:text-5xl">
+              Bekijk je 3D print realtime in de browser
+            </h1>
+            <p className="mt-6 text-lg text-slate-600">
+              Upload je 3D-model en ontdek hoe de print eruitziet in een glanzende WebGL-viewer. Geen wachttijd, geen upload naar
+              servers — wel inzicht in meshkwaliteit en een ervaring in X3DPrints-stijl.
+            </p>
+            <ul className="mt-8 grid gap-3 text-sm text-slate-600 sm:grid-cols-2">
+              {bullets.map((item) => (
+                <li
+                  key={item}
+                  className="flex items-start gap-2 rounded-2xl border border-slate-200/70 bg-white/70 px-4 py-3 shadow-sm"
+                >
+                  <span className="mt-1 h-2 w-2 rounded-full bg-sky-400" aria-hidden />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </Reveal>
+        </Container>
+      </section>
+
+      <section className="pb-20">
+        <Container>
+          <Reveal>
+            <ModelViewer />
+          </Reveal>
+        </Container>
+      </section>
+
+      <section className="pb-20">
+        <Container>
+          <Reveal className="grid gap-6 lg:grid-cols-3">
+            {highlights.map((item) => (
+              <GlassCard key={item.title} className="bg-white/50">
+                <h2 className="text-lg font-semibold text-slate-900">{item.title}</h2>
+                <p className="mt-3 text-sm text-slate-600">{item.description}</p>
+              </GlassCard>
+            ))}
+          </Reveal>
+        </Container>
+      </section>
+
+      <section className="pb-24">
+        <Container>
+          <Reveal className="rounded-3xl border border-slate-200/70 bg-white/80 p-8 shadow-lg">
+            <h2 className="text-2xl font-semibold text-slate-900">Van preview naar print</h2>
+            <p className="mt-4 max-w-2xl text-base text-slate-600">
+              Gebruik de viewer als snelle sanity-check. Zo kunnen we samen efficiënter schakelen wanneer je een offerte of
+              maatwerktraject aanvraagt.
+            </p>
+            <div className="mt-8 grid gap-4 md:grid-cols-3">
+              {workflow.map((item) => (
+                <div
+                  key={item.step}
+                  className="rounded-3xl border border-slate-200/80 bg-white/70 p-5 text-sm text-slate-600 shadow-sm"
+                >
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">{item.step}</p>
+                  <p className="mt-3 text-slate-700">{item.copy}</p>
+                </div>
+              ))}
+            </div>
+            <p className="mt-6 text-xs text-slate-500">
+              Tip: Deel de face/vertex-count bij je aanvraag. Zo kunnen we meteen inschatten welke printinstellingen geschikt zijn.
+            </p>
+          </Reveal>
+        </Container>
+      </section>
+    </main>
+  )
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -15,6 +15,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { path: "/materials",       changeFrequency: "monthly" as const, priority: 0.8 },
     { path: "/pricing",         changeFrequency: "weekly"  as const, priority: 0.8 },
     { path: "/portfolio",       changeFrequency: "weekly"  as const, priority: 0.8 },
+    { path: "/viewer",          changeFrequency: "weekly"  as const, priority: 0.7 },
     { path: "/about",           changeFrequency: "monthly" as const, priority: 0.6 },
     { path: "/contact",         changeFrequency: "monthly" as const, priority: 0.6 },
     { path: "/faq",             changeFrequency: "monthly" as const, priority: 0.6 },

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -11,6 +11,7 @@ import { AnimatePresence, motion } from "framer-motion"
 const NAV = [
   { href: "/services", label: "Services" },
   { href: "/materials", label: "Materialen" },
+  { href: "/viewer", label: "3D Viewer" },
   { href: "/portfolio", label: "Portfolio" },
   { href: "/about", label: "Over ons" },
   { href: "/pricing", label: "Prijzen" },

--- a/components/ModelViewer.tsx
+++ b/components/ModelViewer.tsx
@@ -1,0 +1,433 @@
+"use client"
+
+import type { DragEvent } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { Canvas } from "@react-three/fiber"
+import { Center, ContactShadows, Environment, Html, OrbitControls } from "@react-three/drei"
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion"
+import {
+  AlertCircle,
+  CheckCircle2,
+  Gauge,
+  Loader2,
+  RotateCw,
+  ShieldCheck,
+  Upload,
+  XCircle,
+} from "lucide-react"
+import * as THREE from "three"
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader"
+import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader"
+import { STLLoader } from "three/examples/jsm/loaders/STLLoader"
+
+import { cn } from "@/lib/utils"
+
+const ACCEPTED_EXTENSIONS = ["stl", "obj", "glb", "gltf"] as const
+const MAX_FILE_SIZE = 15 * 1024 * 1024 // 15 MB
+const MAX_FILE_SIZE_MB = Math.round(MAX_FILE_SIZE / (1024 * 1024))
+
+const material = new THREE.MeshStandardMaterial({
+  color: new THREE.Color("#60a5fa"),
+  metalness: 0.25,
+  roughness: 0.35,
+})
+
+function disposeMaterial(mat: THREE.Material | THREE.Material[]) {
+  if (Array.isArray(mat)) {
+    mat.forEach((m) => disposeMaterial(m))
+    return
+  }
+  if ("dispose" in mat) {
+    mat.dispose()
+  }
+}
+
+function disposeModel(object: THREE.Object3D | null) {
+  if (!object) return
+  object.traverse((child) => {
+    if ((child as THREE.Mesh).isMesh) {
+      const mesh = child as THREE.Mesh
+      mesh.geometry.dispose()
+      if (mesh.material) {
+        disposeMaterial(mesh.material)
+      }
+    }
+  })
+}
+
+type ModelStats = {
+  vertices: number
+  faces: number
+  ext: string
+  fileName: string
+}
+
+type ViewerState = "idle" | "loading" | "ready" | "error"
+
+async function loadModel(file: File, ext: typeof ACCEPTED_EXTENSIONS[number]) {
+  if (ext === "stl") {
+    const loader = new STLLoader()
+    const buffer = await file.arrayBuffer()
+    const geometry = loader.parse(buffer)
+    geometry.computeVertexNormals()
+    const mesh = new THREE.Mesh(geometry, material.clone())
+    mesh.castShadow = true
+    mesh.receiveShadow = true
+    const group = new THREE.Group()
+    group.add(mesh)
+    return group
+  }
+
+  if (ext === "obj") {
+    const loader = new OBJLoader()
+    const text = await file.text()
+    const group = loader.parse(text)
+    group.traverse((child) => {
+      if ((child as THREE.Mesh).isMesh) {
+        const mesh = child as THREE.Mesh
+        mesh.material = material.clone()
+        mesh.castShadow = true
+        mesh.receiveShadow = true
+      }
+    })
+    return group
+  }
+
+  const loader = new GLTFLoader()
+  const arrayBuffer = await file.arrayBuffer()
+
+  const gltf = await loader.parseAsync(arrayBuffer, "")
+  const scene = gltf.scene ?? gltf.scenes?.[0]
+  if (!scene) {
+    throw new Error("Kon geen mesh vinden in dit bestand.")
+  }
+  scene.traverse((child) => {
+    if ((child as THREE.Mesh).isMesh) {
+      const mesh = child as THREE.Mesh
+      if (!Array.isArray(mesh.material)) {
+        mesh.material = material.clone()
+      }
+      mesh.castShadow = true
+      mesh.receiveShadow = true
+    }
+  })
+  return scene
+}
+
+function extractStats(object: THREE.Object3D, ext: string, fileName: string): ModelStats {
+  let vertices = 0
+  let faces = 0
+  object.traverse((child) => {
+    if ((child as THREE.Mesh).isMesh) {
+      const mesh = child as THREE.Mesh
+      const position = mesh.geometry.getAttribute("position")
+      if (position) {
+        vertices += position.count
+        faces += Math.round(position.count / 3)
+      }
+    }
+  })
+  return {
+    vertices,
+    faces,
+    ext,
+    fileName,
+  }
+}
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat("nl-BE").format(value)
+}
+
+export default function ModelViewer({ className }: { className?: string }) {
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const prefersReducedMotion = useReducedMotion()
+
+  const [state, setState] = useState<ViewerState>("idle")
+  const [error, setError] = useState<string | null>(null)
+  const [model, setModel] = useState<THREE.Object3D | null>(null)
+  const [modelKey, setModelKey] = useState(0)
+  const [stats, setStats] = useState<ModelStats | null>(null)
+  const [dragActive, setDragActive] = useState(false)
+  const [autoRotate, setAutoRotate] = useState(() => !prefersReducedMotion)
+
+  useEffect(() => {
+    if (prefersReducedMotion) {
+      setAutoRotate(false)
+    }
+  }, [prefersReducedMotion])
+
+  useEffect(() => {
+    return () => {
+      disposeModel(model)
+    }
+  }, [model])
+
+  const reset = useCallback(() => {
+    setState("idle")
+    setError(null)
+    setStats(null)
+    setAutoRotate(!prefersReducedMotion)
+    setModel((previous) => {
+      disposeModel(previous)
+      return null
+    })
+    setModelKey((key) => key + 1)
+    if (inputRef.current) {
+      inputRef.current.value = ""
+    }
+  }, [prefersReducedMotion])
+
+  const handleFiles = useCallback(
+    async (fileList: FileList | null) => {
+      if (!fileList || fileList.length === 0) return
+      const file = fileList[0]
+      const ext = file.name.split(".").pop()?.toLowerCase()
+      if (!ext || !ACCEPTED_EXTENSIONS.includes(ext as typeof ACCEPTED_EXTENSIONS[number])) {
+        setState("error")
+        setError("Bestandsformaat wordt niet ondersteund. Kies een STL, OBJ, GLB of GLTF.")
+        return
+      }
+      if (file.size > MAX_FILE_SIZE) {
+        setState("error")
+        setError("Bestand is groter dan 15 MB. Vraag een geoptimaliseerde export aan.")
+        return
+      }
+
+      setState("loading")
+      setError(null)
+
+      try {
+        const loaded = await loadModel(file, ext as typeof ACCEPTED_EXTENSIONS[number])
+        const statsPayload = extractStats(loaded, ext, file.name)
+        setStats(statsPayload)
+        setModel((previous) => {
+          disposeModel(previous)
+          return loaded
+        })
+        setModelKey((key) => key + 1)
+        setState("ready")
+      } catch (err) {
+        console.error(err)
+        setState("error")
+        setError(
+          err instanceof Error
+            ? err.message
+            : "We konden dit model niet openen. Probeer een ander formaat of controleer of het bestand compleet is."
+        )
+        setModel((previous) => {
+          disposeModel(previous)
+          return null
+        })
+        setStats(null)
+      }
+    },
+    []
+  )
+
+  const onDrop = useCallback(
+    (event: DragEvent<HTMLLabelElement>) => {
+      event.preventDefault()
+      setDragActive(false)
+      if (event.dataTransfer?.files?.length) {
+        void handleFiles(event.dataTransfer.files)
+      }
+    },
+    [handleFiles]
+  )
+
+  const onDragOver = useCallback((event: DragEvent<HTMLLabelElement>) => {
+    event.preventDefault()
+    setDragActive(true)
+  }, [])
+
+  const onDragLeave = useCallback((event: DragEvent<HTMLLabelElement>) => {
+    event.preventDefault()
+    if (!containerRef.current?.contains(event.relatedTarget as Node)) {
+      setDragActive(false)
+    }
+  }, [])
+
+  const viewerOverlay = useMemo(() => {
+    if (state === "ready" || state === "loading") return null
+    return (
+      <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-3 bg-[radial-gradient(circle_at_top,#0f172a80,transparent)] px-6 text-center">
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4 }}
+          className="flex flex-col items-center gap-3"
+        >
+          <Upload className="h-10 w-10 text-sky-300" aria-hidden />
+          <div className="text-lg font-semibold text-white">Upload een STL, OBJ of GLB</div>
+          <p className="max-w-md text-sm text-slate-300">
+            Je bestand blijft volledig lokaal in de browser. Sleep het hierheen of gebruik de uploadknop.
+          </p>
+        </motion.div>
+      </div>
+    )
+  }, [state])
+
+  return (
+    <div ref={containerRef} className={cn("grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]", className)}>
+      <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 shadow-2xl">
+        <Canvas
+          key={modelKey}
+          dpr={[1, 1.8]}
+          camera={{ position: [3.6, 2.4, 3.6], fov: 45, near: 0.1, far: 100 }}
+          gl={{ antialias: true, preserveDrawingBuffer: false, powerPreference: "high-performance" }}
+          shadows
+        >
+          <color attach="background" args={["#030712"]} />
+          <ambientLight intensity={0.4} />
+          <directionalLight position={[5, 8, 5]} intensity={0.6} castShadow shadow-mapSize-width={1024} shadow-mapSize-height={1024} />
+          <spotLight position={[-5, 6, -4]} angle={0.6} intensity={0.4} castShadow />
+
+          <Center>
+            {model ? <primitive object={model} dispose={undefined} /> : null}
+          </Center>
+
+          <ContactShadows opacity={0.4} scale={10} blur={1.4} far={4.5} />
+          <Environment preset="city" intensity={0.65} />
+          <OrbitControls
+            enablePan
+            enableZoom
+            autoRotate={autoRotate}
+            autoRotateSpeed={0.75}
+            enableDamping
+            dampingFactor={0.08}
+            makeDefault
+          />
+
+          {state === "loading" ? (
+            <Html center>
+              <div className="flex items-center gap-2 rounded-full bg-slate-900/80 px-4 py-2 text-xs font-medium text-slate-100">
+                <Loader2 className="h-4 w-4 animate-spin" /> Model wordt geladen...
+              </div>
+            </Html>
+          ) : null}
+        </Canvas>
+        {viewerOverlay}
+      </div>
+
+      <div className="space-y-4">
+        <label
+          onDragOver={onDragOver}
+          onDragLeave={onDragLeave}
+          onDrop={onDrop}
+          className={cn(
+            "relative flex cursor-pointer flex-col items-center justify-center gap-3 rounded-3xl border border-dashed p-6 text-center transition",
+            dragActive ? "border-sky-400/80 bg-sky-500/5" : "border-slate-400/40 bg-white/10 hover:border-slate-300/60"
+          )}
+        >
+          <input
+            ref={inputRef}
+            type="file"
+            name="model"
+            accept=".stl,.obj,.glb,.gltf"
+            className="sr-only"
+            onChange={(event) => {
+              void handleFiles(event.target.files)
+            }}
+          />
+          <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-sky-500/10">
+            <Upload className="h-5 w-5 text-sky-400" aria-hidden />
+          </div>
+          <div className="text-sm font-semibold text-slate-900">Sleep je bestand hierheen</div>
+          <p className="text-xs text-slate-600">
+            Ondersteunt STL, OBJ en GLB (max. {MAX_FILE_SIZE_MB} MB). Bestand blijft lokaal.
+          </p>
+        </label>
+
+        <div className="rounded-3xl border border-slate-200/70 bg-white/70 p-4 shadow-sm">
+          <div className="flex items-start gap-3">
+            <ShieldCheck className="mt-0.5 h-5 w-5 text-emerald-500" aria-hidden />
+            <div className="space-y-1 text-sm">
+              <p className="font-semibold text-slate-900">Privacy eerst</p>
+              <p className="text-slate-600">
+                Het model wordt nooit naar onze servers verzonden. Alles draait binnen je browser en verdwijnt zodra je de pagina sluit.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <AnimatePresence mode="wait">
+          {state === "error" && error ? (
+            <motion.div
+              key="error"
+              initial={{ opacity: 0, y: -6 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -6 }}
+              className="flex items-start gap-3 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700"
+            >
+              <AlertCircle className="h-5 w-5" aria-hidden />
+              <div>
+                <p className="font-medium">Er ging iets mis</p>
+                <p>{error}</p>
+              </div>
+            </motion.div>
+          ) : null}
+
+          {state === "ready" && stats ? (
+            <motion.div
+              key="ready"
+              initial={{ opacity: 0, y: -6 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -6 }}
+              className="space-y-3 rounded-3xl border border-emerald-200 bg-emerald-50/70 p-4 text-sm text-emerald-900"
+            >
+              <div className="flex items-center gap-2 font-semibold">
+                <CheckCircle2 className="h-5 w-5" aria-hidden />
+                {stats.fileName}
+              </div>
+              <div className="grid grid-cols-2 gap-2 text-xs text-emerald-800">
+                <div className="rounded-2xl border border-emerald-200/70 bg-white/60 p-3">
+                  <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wide text-emerald-700">
+                    <Gauge className="h-4 w-4" aria-hidden />
+                    Mesh stats
+                  </div>
+                  <p className="mt-2 text-sm font-semibold text-emerald-900">{formatNumber(stats.faces)} faces</p>
+                  <p className="text-xs text-emerald-700">{formatNumber(stats.vertices)} vertices</p>
+                </div>
+                <div className="rounded-2xl border border-emerald-200/70 bg-white/60 p-3">
+                  <p className="text-[11px] font-semibold uppercase tracking-wide text-emerald-700">Bestand</p>
+                  <p className="mt-2 text-sm font-semibold text-emerald-900">.{stats.ext}</p>
+                  <button
+                    type="button"
+                    onClick={() => setAutoRotate((value) => !value)}
+                    className="mt-3 inline-flex items-center gap-1 rounded-full border border-emerald-200/70 px-3 py-1 text-xs font-semibold text-emerald-800 transition hover:bg-emerald-100"
+                  >
+                    <RotateCw className="h-3.5 w-3.5" aria-hidden />
+                    {autoRotate ? "Auto-rotate aan" : "Auto-rotate uit"}
+                  </button>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={reset}
+                className="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-white/80 px-3 py-1.5 text-xs font-semibold text-emerald-800 transition hover:bg-white"
+              >
+                <XCircle className="h-4 w-4" aria-hidden />
+                Verwijder model
+              </button>
+            </motion.div>
+          ) : null}
+
+          {state === "loading" ? (
+            <motion.div
+              key="loading"
+              initial={{ opacity: 0, y: -6 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -6 }}
+              className="flex items-center gap-3 rounded-2xl border border-slate-200 bg-white/80 p-4 text-sm text-slate-700"
+            >
+              <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
+              Model wordt voorbereid...
+            </motion.div>
+          ) : null}
+        </AnimatePresence>
+      </div>
+    </div>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "x3dprints",
       "version": "0.1.0",
       "dependencies": {
+        "@react-three/drei": "^10.7.7",
+        "@react-three/fiber": "^9.0.0",
         "@tailwindcss/typography": "^0.5.16",
         "clsx": "^2.1.1",
         "framer-motion": "^12.23.12",
@@ -31,6 +33,7 @@
         "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
         "tailwind-merge": "^3.3.1",
+        "three": "^0.171.0",
         "unified": "^11.0.5"
       },
       "devDependencies": {
@@ -1420,6 +1423,21 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@emnapi/core": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
@@ -2114,6 +2132,24 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.1.0.tgz",
+      "integrity": "sha512-Obb0/gEd/HReTlg8ttaYk+0m62gQJmCblMOjHSMHRrBP2zdfKMHLCRbh/6ex9fSUJMKdjjIEiohwkbGD3wj2Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -2329,6 +2365,102 @@
       "engines": {
         "node": ">=12.4.0"
       }
+    },
+    "node_modules/@react-three/drei": {
+      "version": "10.7.7",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.7.tgz",
+      "integrity": "sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^3.1.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.8.3",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.4",
+        "tunnel-rat": "^0.1.2",
+        "use-sync-external-store": "^1.4.0",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19",
+        "react-dom": "^19",
+        "three": ">=0.159"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.4.0.tgz",
+      "integrity": "sha512-k4iu1R6e5D54918V4sqmISUkI5OgTw3v7/sDRKEC632Wd5g2WBtUS5gyG63X0GJO/HZUj1tsjSXfyzwrUHZl1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/react-reconciler": "^0.32.0",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-reconciler": "^0.31.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.25.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -2754,6 +2886,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "dev": true,
       "optional": true
@@ -2766,6 +2904,12 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2842,11 +2986,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.1.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
       "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2862,6 +3011,36 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.32.3",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.32.3.tgz",
+      "integrity": "sha512-cMi5ZrLG7UtbL7LTK6hq9w/EZIRk4Mf1Z5qHoI+qBh7/WkYkFXQ7gOto2yfUvPzF5ERMAhaXS5eTQ2SAnHjLzA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.181.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.181.0.tgz",
+      "integrity": "sha512-MLF1ks8yRM2k71D7RprFpDb9DOX0p22DbdPqT/uAkc6AtQXjxWCVDjCy23G9t1o8HcQPk7woD2NIyiaWcWPYmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.22.0"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2873,6 +3052,12 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/parser": {
@@ -3370,6 +3555,30 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.66.tgz",
+      "integrity": "sha512-YA2hLrwLpDsRueNDXIMqN9NTzD6bCDkuXbOSe0heS+f8YE8usA6Gbv1prj81pzVHrbaAma7zObnIC+I6/sXJgA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -4384,6 +4593,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bowser": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.12.1.tgz",
@@ -4455,6 +4693,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -4513,6 +4775,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.0.tgz",
+      "integrity": "sha512-w5oULNpijgTRH0ARFJJ0R5ct1nUM3R3WP7/b8A6j9uTGpRfnsypc/RBMPQV8JQDPayUe37p/TZZY1PcUr4czOQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.11.0",
+        "npm": ">=10.8.2"
+      },
+      "peerDependencies": {
+        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -4669,11 +4944,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4700,7 +4992,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -4846,6 +5137,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -4881,6 +5181,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6005,6 +6311,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -6298,6 +6610,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -6639,6 +6957,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/hls.js": {
+      "version": "1.6.14",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.14.tgz",
+      "integrity": "sha512-CSpT2aXsv71HST8C5ETeVo+6YybqCpHBiYrCRQSn3U5QUZuLTSsvtq/bj+zuvjLVADeKxoebzo16OkH8m1+65Q==",
+      "license": "Apache-2.0"
+    },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
@@ -6649,6 +6973,26 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -6658,6 +7002,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -7133,6 +7483,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -7360,7 +7716,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -7392,6 +7747,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/jiti": {
@@ -7493,6 +7869,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -7798,6 +8183,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
       }
     },
     "node_modules/magic-string": {
@@ -8675,6 +9070,21 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
+      "license": "MIT"
     },
     "node_modules/micromark-extension-gfm": {
       "version": "3.0.0",
@@ -9823,7 +10233,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9901,6 +10310,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9909,6 +10324,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
       }
     },
     "node_modules/prop-types": {
@@ -9990,6 +10415,42 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.31.0.tgz",
+      "integrity": "sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.25.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-reconciler/node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT"
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -10664,6 +11125,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -10981,7 +11451,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -10994,7 +11463,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11162,6 +11630,32 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
@@ -11646,6 +12140,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
@@ -11676,6 +12179,44 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/three": {
+      "version": "0.171.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.171.0.tgz",
+      "integrity": "sha512-Y/lAXPaKZPcEdkKjh0JOAHVv8OOnv/NDJqm0wjfCzyQmfKxV7zvkwsnBgPBKTzJHToSOhRGQAGbPJObT59B/PQ==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.8.3.tgz",
+      "integrity": "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -11698,6 +12239,36 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/troika-three-text": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
     },
     "node_modules/trough": {
       "version": "2.2.0",
@@ -11727,6 +12298,43 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -12052,11 +12660,29 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",
@@ -12110,11 +12736,21 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -12294,6 +12930,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.16",
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.0.0",
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.12",
     "github-slugger": "^2.0.0",
@@ -32,6 +34,7 @@
     "remark-rehype": "^11.1.2",
     "remark-smartypants": "^3.0.2",
     "tailwind-merge": "^3.3.1",
+    "three": "^0.171.0",
     "unified": "^11.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Wat
- voeg een nieuwe /viewer route toe met een dynamische WebGL-preview en begeleidende copy
- introduceer een clientside ModelViewer-component met bestandsvalidatie, privacycopy en mesh-statistieken
- breid de navigatie en sitemap uit en installeer de nodige @react-three/three dependencies

## Waarom
- klanten kunnen hun 3D-model nu onmiddellijk in 3D bekijken zonder uploads naar de server
- de pagina sluit aan bij de merkstijl en benadrukt privacy, validatie en performance zoals gevraagd

## Testplan
- [ ] Build OK
- [ ] Lint OK (npm run lint geeft bestaande waarschuwingen terug)
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6917d0a5b1b4833298a211344143cb8e)