### PR TITLE
Fix reveal animation to avoid hidden content on load

### DIFF
--- a/components/AnimatedSection.tsx
+++ b/components/AnimatedSection.tsx
@@ -7,10 +7,11 @@ export default function AnimatedSection({ children, className = "" }: { children
   return (
     <motion.section
       className={className}
-      initial={prefersReduced ? false : { opacity: 0, y: 20 }}
+      // Keep opacity at 1 on mount so sections remain visible immediately after load.
+      initial={prefersReduced ? false : { opacity: 1, y: 12 }}
       whileInView={prefersReduced ? {} : { opacity: 1, y: 0 }}
       viewport={{ once: false, amount: 0.2 }}
-      transition={{ duration: 0.5 }}
+      transition={{ duration: 0.45, ease: "easeOut" }}
     >
       {children}
     </motion.section>

--- a/components/Reveal.tsx
+++ b/components/Reveal.tsx
@@ -14,10 +14,11 @@ export default function Reveal({ children, delay = 0.1, className }: RevealProps
   return (
     <motion.div
       className={className}
-      initial={prefersReduced ? false : { opacity: 0, y: 16 }}
+      // Keep opacity at 1 on mount so content is immediately visible after SSR hydration.
+      initial={prefersReduced ? false : { opacity: 1, y: 12 }}
       whileInView={prefersReduced ? {} : { opacity: 1, y: 0 }}
       viewport={{ once: true, amount: 0.2 }}
-      transition={{ duration: 0.6, delay }}
+      transition={{ duration: 0.45, ease: "easeOut", delay }}
     >
       {children}
     </motion.div>


### PR DESCRIPTION
## Wat
- Zorgt dat Reveal- en AnimatedSection-componenten geen opacity-fade meer gebruiken bij initial load zodat content meteen zichtbaar is.
- Versoepelt de animatie-instellingen (kortere duur, easeOut) voor een subtielere beweging.

## Waarom
- Pagina's bleven onzichtbaar tot je scrolde door de 0→1 fade, wat een storende eerste indruk gaf.

## Testplan
- [ ] Build OK
- [x] Lint OK (`npm run lint` met bestaande waarschuwingen uit de codebase)
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video
- n.v.t.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691889cb7a808332a12a067584a0701c)