### PR TITLE
Add filament photo gallery to material detail pages

### DIFF
--- a/app/(pages)/materials/[slug]/page.tsx
+++ b/app/(pages)/materials/[slug]/page.tsx
@@ -1,5 +1,6 @@
 // app/(pages)/materials/[slug]/page.tsx
 import type { Metadata } from "next"
+import Image from "next/image"
 import Link from "next/link"
 import { notFound } from "next/navigation"
 import Reveal from "@/components/Reveal"
@@ -11,6 +12,10 @@ import {
   MATERIAL_DETAIL_SLUGS,
   type MaterialDetailContent,
 } from "@/content/material-details"
+import {
+  MATERIAL_GALLERY,
+  type MaterialGalleryItem,
+} from "@/content/material-gallery"
 
 export async function generateMetadata({
   params,
@@ -114,6 +119,47 @@ function SwatchList({
   )
 }
 
+function MaterialGallery({
+  items,
+}: {
+  items?: MaterialGalleryItem[]
+}) {
+  if (!items || items.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {items.map((item, index) => (
+        <figure
+          key={item.src}
+          className="group overflow-hidden rounded-2xl border border-slate-200/70 bg-white/70 shadow-sm"
+        >
+          <div className="relative aspect-[4/3]">
+            <Image
+              src={`/images/filament/${item.src}`}
+              alt={item.alt}
+              fill
+              className="object-cover transition duration-500 group-hover:scale-[1.02]"
+              sizes="(min-width: 1024px) 45vw, (min-width: 640px) 50vw, 100vw"
+              priority={index === 0}
+            />
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-0 bg-gradient-to-t from-slate-900/30 via-slate-900/0 to-transparent opacity-0 transition group-hover:opacity-100"
+            />
+          </div>
+          {item.caption ? (
+            <figcaption className="px-4 pb-4 pt-3 text-sm text-slate-600">
+              {item.caption}
+            </figcaption>
+          ) : null}
+        </figure>
+      ))}
+    </div>
+  )
+}
+
 export default async function MaterialDetailPage({
   params,
 }: {
@@ -127,6 +173,7 @@ export default async function MaterialDetailPage({
   }
 
   const material = MATERIALS[detail.key]
+  const galleryItems = MATERIAL_GALLERY[detail.key]
 
   const productJsonLd = {
     "@context": "https://schema.org",
@@ -187,6 +234,12 @@ export default async function MaterialDetailPage({
                 </span>
               ) : null}
             </div>
+
+            {galleryItems && galleryItems.length > 0 ? (
+              <div className="mt-10">
+                <MaterialGallery items={galleryItems} />
+              </div>
+            ) : null}
 
             <div className="mt-8 flex flex-wrap items-center gap-4">
               <ShimmerButton href="/contact">Vraag offerte of advies</ShimmerButton>

--- a/content/material-gallery.ts
+++ b/content/material-gallery.ts
@@ -1,0 +1,191 @@
+// content/material-gallery.ts
+import type { MaterialKey } from "@/lib/materials"
+
+export type MaterialGalleryItem = {
+  src: string
+  alt: string
+  caption?: string
+}
+
+export const MATERIAL_GALLERY: Partial<Record<MaterialKey, MaterialGalleryItem[]>> = {
+  PLA_TOUGH_PLUS: [
+    {
+      src: "pla_toughPlus_clothes_(1).webp",
+      alt: "Blauwe kledingclip geprint in PLA Tough+ die spanning opvangt",
+      caption: "PLA Tough+ houdt clips en brackets stevig onder belasting.",
+    },
+    {
+      src: "pla_toughplus_new_bracket_(1).webp",
+      alt: "Rode verstevigingsbeugel geprint in PLA Tough+",
+      caption: "Functionele beugels blijven maatvast dankzij PLA Tough+.",
+    },
+  ],
+  PLA_MATTE: [
+    {
+      src: "pla_matteClock_PC.webp",
+      alt: "Minimalistische wandklok geprint in mat PLA",
+      caption: "Mat PLA geeft prototypes een gegoten, designwaardige uitstraling.",
+    },
+    {
+      src: "pla_matte_Car_PC.webp",
+      alt: "Dashboardpaneel in diepblauw PLA Matte",
+      caption: "Complexe vormen ogen strak door de lage glans van PLA Matte.",
+    },
+  ],
+  PLA_GLOW: [
+    {
+      src: "pla_glow_model_3.webp",
+      alt: "Glow-in-the-dark decorobject geprint in PLA Glow",
+      caption: "PLA Glow laadt snel op voor zichtbare veiligheid en fun.",
+    },
+    {
+      src: "pla_glow_model_6.webp",
+      alt: "Oplichtende PLA Glow accessoires in het donker",
+      caption: "De fosforescerende pigmenten blijven minutenlang nageven.",
+    },
+  ],
+  PLA_MARBLE: [
+    {
+      src: "marble_cookie.webp",
+      alt: "Organische schaal geprint in PLA Marble",
+      caption: "Marmerpigmenten creëren luxe woonaccessoires met textuur.",
+    },
+    {
+      src: "marble_david.webp",
+      alt: "Buste met realistische marmerlook in PLA Marble",
+      caption: "Perfect voor kunstreproducties en premium decor.",
+    },
+  ],
+  PLA_SPARKLE: [
+    {
+      src: "Bambu_PLA_Sparkle_filament_3.webp",
+      alt: "Close-up van glitterende PLA Sparkle spoel",
+      caption: "PLA Sparkle vangt het licht met fijne glitters.",
+    },
+    {
+      src: "Bambu_PLA_Sparkle_filament_7.webp",
+      alt: "Fonkelende geprinte onderdelen in PLA Sparkle",
+      caption: "Ideaal voor showpieces en opvallende merchandising.",
+    },
+  ],
+  PLA_METAL: [
+    {
+      src: "Metal_model_2.webp",
+      alt: "Metaalachtig prototype geprint in PLA Metal",
+      caption: "PLA Metal combineert industriële look met lage massa.",
+    },
+    {
+      src: "Metal_model_3.webp",
+      alt: "Detail van technische plaat in PLA Metal",
+      caption: "De metallic glans versterkt scherpe lijnen en logo's.",
+    },
+  ],
+  PLA_AERO: [
+    {
+      src: "Aero_birdhouse_pc_3.webp",
+      alt: "Lichtgewicht vogelhuis geprint in PLA Aero",
+      caption: "PLA Aero houdt grote objecten licht en toch stijf.",
+    },
+    {
+      src: "aero_sunglass_clip.webp",
+      alt: "Dunne zonnebrilclip uit PLA Aero op tafel",
+      caption: "Foamed PLA is ideaal voor clips en draagbare accessoires.",
+    },
+  ],
+  PLA_SILK_PLUS: [
+    {
+      src: "PLA_SilkPlus_model_1.webp",
+      alt: "Zijdeglanzende sculptuur geprint in PLA Silk+",
+      caption: "PLA Silk+ levert spiegelende highlight voor premium showpieces.",
+    },
+    {
+      src: "PLA_SilkPlus_model_3.webp",
+      alt: "PLA Silk+ vaas met glanzende contouren",
+      caption: "Gekleurde Silk+ prints vallen meteen op in display's.",
+    },
+  ],
+  PLA_BASIC_GRADIENT: [
+    {
+      src: "PLA_Gradient_prints_2.webp",
+      alt: "Set vazen met zachte kleurverlopen in PLA Basic Gradient",
+      caption: "Voorverlopen spoelen creëren unieke kleurovergangen.",
+    },
+    {
+      src: "PLA_Gradient_prints_8.webp",
+      alt: "Close-up van PLA Gradient prints met meerdere tinten",
+      caption: "Elke print heeft een eigen verloop door de spoelopbouw.",
+    },
+  ],
+  PLA_BASIC: [
+    {
+      src: "pla_basic_Mecha-tuya.webp",
+      alt: "Mechanische behuizing geprint in PLA Basic",
+      caption: "PLA Basic is de allrounder voor prototypes en maquettes.",
+    },
+    {
+      src: "pla_basic_domino-tuya.webp",
+      alt: "Domino's in verschillende kleuren PLA Basic",
+      caption: "Veel kleurkeuze maakt PLA Basic ideaal voor educatieve sets.",
+    },
+  ],
+  PETG: [
+    {
+      src: "petg_1.webp",
+      alt: "PETG montagebeugel met stevige infill",
+      caption: "PETG combineert impactbestendigheid met hittebestendigheid.",
+    },
+    {
+      src: "petg_2.webp",
+      alt: "Technisch onderdeel geprint in PETG",
+      caption: "Perfect voor functionele toepassingen die tegen een stootje kunnen.",
+    },
+  ],
+  PLA_TRANSLUCENT: [
+    {
+      src: "Translucent_K2_Butterfly.webp",
+      alt: "Lichtdoorlatende vlinderlamp geprint in PLA Translucent",
+      caption: "Translucent PLA laat licht diffuus door voor sfeermakers.",
+    },
+    {
+      src: "Translucent_K2_glass.webp",
+      alt: "Decorobject dat licht vangt in PLA Translucent",
+      caption: "Perfect voor lampenkappen en signage met gloed.",
+    },
+  ],
+  PLA_SILK_MULTI_COLOR: [
+    {
+      src: "pla_silk_gradient_model_1.webp",
+      alt: "Multicolor PLA Silk print met regenboogverloop",
+      caption: "PLA Silk Multi-Color levert vloeiende regenboogverlopen.",
+    },
+    {
+      src: "pla_silk_gradient_model_2.webp",
+      alt: "Detail van PLA Silk Multi-Color vaas met glans",
+      caption: "De zijdeglans accentueert elke tint in het verloop.",
+    },
+  ],
+  PLA_CF: [
+    {
+      src: "PLA_CF_Shelf_2.webp",
+      alt: "Robuuste plankdrager geprint in PLA-CF",
+      caption: "Carbon gevuld PLA houdt functionele onderdelen stijf.",
+    },
+    {
+      src: "PLA_CF_Vise.webp",
+      alt: "Bankschroefklem geprint in PLA-CF",
+      caption: "Ideaal voor tooling en klemmen die niet mogen doorbuigen.",
+    },
+  ],
+  PLA_WOOD: [
+    {
+      src: "PLA_Wood_Feature_1_-4.webp",
+      alt: "Vaas met warme houtnerf geprint in PLA Wood",
+      caption: "PLA Wood geeft prints een authentieke houtstructuur.",
+    },
+    {
+      src: "PLA_Wood_Feature_1_-5.webp",
+      alt: "Close-up van PLA Wood print met natuurlijke tint",
+      caption: "Perfect voor interieuraccenten en maquettes.",
+    },
+  ],
+}


### PR DESCRIPTION
## Wat
- voeg een fotogalerij toe aan elke materiaaldetailpagina met een moderne, responsieve lay-out
- beheer de galerijdata per filament in `content/material-gallery.ts`

## Waarom
- toont de nieuw aangeleverde foto's per filament in lijn met de rest van de pagina

## Testplan
- [ ] Build OK
- [x] Lint OK (met bestaande waarschuwingen)
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6918907792288332a3c495bbec2101f5)