### PR TITLE
fix: update TPU swatch colors

### DIFF
--- a/lib/materials.ts
+++ b/lib/materials.ts
@@ -350,7 +350,12 @@ export const MATERIALS: Record<MaterialKey, MaterialInfo> = {
     features: ["Flexibel", "Schokabsorberend"],
     swatches: [
       { label: "Zwart", color: "#000000", inStock: true },
-      { label: "Wit", color: "#ffffff", inStock: false },
+      { label: "Grijs", color: "#9ca3af", inStock: true },
+      { label: "Wit", color: "#ffffff", inStock: true },
+      { label: "Rood", color: "#ef4444", inStock: true },
+      { label: "Geel", color: "#facc15", inStock: true },
+      { label: "Neon Groen", color: "#4ade80", inStock: true },
+      { label: "Blauw", color: "#2563eb", inStock: true },
     ],
   },
 };


### PR DESCRIPTION
## Wat
- update de TPU-swatchkleuren zodat ze overeenkomen met het huidige assortiment bij Bambu Lab

## Waarom
- houdt de materiaalpagina up-to-date met de beschikbare TPU-kleuren voor klanten

## Testplan
- [ ] Build OK
- [x] Lint OK (warnings over bestaande eslint-disable directives)
- [ ] Lighthouse ≥ 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen console errors

## Screenshots/Video
- n.v.t.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691897f515008332a3af4839c730f195)