### PR TITLE
Add Antwerpen location landing page

### DIFF
--- a/content/locations/3d-printen-in-antwerpen.md
+++ b/content/locations/3d-printen-in-antwerpen.md
@@ -1,0 +1,94 @@
+# 3D printen in Antwerpen: van haven tot binnenstad
+
+Zoek je een betrouwbare partner voor **3D printen in Antwerpen**? X3DPrints staat klaar voor teams in de haven, bureaus aan het Eilandje, makers in Borgerhout en studenten rond de Universiteit Antwerpen. Vanuit onze studio in Herzele leveren we prototypes, kleine series en maatwerk onderdelen die klaar zijn voor de Scheldestad.
+
+Met onze **3D print service Antwerpen** krijg je snelle offertes, scherpe prijzen en duidelijke materiaalkeuzes. We denken mee over passing, oriëntatie en afwerking zodat je model meteen inzetbaar is – of je nu een maquette wilt voor een pitch aan de Meir, een functioneel onderdeel in de diamantwijk of een display voor een expo in het MAS.
+
+---
+
+## Waarom X3DPrints voor Antwerpen?
+
+- ⚡ **Snel geleverd**: meestal binnen enkele werkdagen verzonden of opgehaald.
+- 🎯 **Precisie**: strakke toleranties voor onderdelen die moeten passen in krappe ruimtes (handig voor installaties in het Havenhuis of labs op Campus Groenenborger).
+- 🌍 **Flexibel in materiaal**: PLA Matte voor zichtwerk, PETG voor stevige toepassingen in de haven, TPU voor flexibele onderdelen zoals bumpers of grips.
+- 🤝 **Persoonlijke aanpak**: korte lijnen, duidelijke communicatie en foto's tijdens productie als je dat wil.
+
+**Lokale touch:** we kennen de mix van industrie en creativiteit in Antwerpen. Denk aan scheepswerven en logistiek langs het Albertkanaal, expo's op het Eilandje, start-ups rond het station Antwerpen-Centraal en ambachtslui in het Zuid. Die variatie vraagt maatwerk; precies wat we bieden met onze **3D printing service Antwerpen**.
+
+---
+
+## Materialen voor projecten in Antwerpen
+
+| Materiaal     | Belangrijkste eigenschap       | Ideaal voor |
+| :------------ | :----------------------------- | :---------- |
+| **PLA Matte** | Strak en detailrijk, veel kleuren | Maquettes van het MAS, display props voor retail in de Stadsfeestzaal |
+| **PETG**      | Sterk en temperatuurbestendig    | Functionele onderdelen voor havenapparatuur of logistieke hulpmiddelen |
+| **TPU**       | Flexibel en schokdempend          | Beschermhoezen, bumpers voor flightcases, custom grips voor tools |
+
+*Tip:* wil je een behuizing voor sensoren aan de kaaien of een schaalmodel voor een pitch in het Designcenter De Winkelhaak? Kies PETG voor stevigheid en PLA voor maximale esthetiek. Twijfel je? Vraag materiaaladvies mee met je bestand via [contact](/contact).
+
+---
+
+## Voor wie in Antwerpen?
+
+### ⚓ Havenbedrijven & logistiek
+Reserveonderdelen, hulphulpmiddelen, custom mounts voor scanners of camera's – snel geleverd richting kaaien of magazijnen.
+
+### 🎨 Creatieve bureaus & musea
+Displays, props en maquettes voor expo's in het MAS, deSingel of het Letterenhuis. Combineer fijne details met een nette afwerking.
+
+### 🎓 Studenten & onderzoek
+Makers op Campus Paardenmarkt of Groenenborger krijgen snel prototypes voor projecten, thesis-onderzoek of robotica.
+
+### 🏢 Kmo's & start-ups
+Van proof-of-concept tot kleine serie. Ideaal voor hardware-teams in Berchem, Borgerhout of rond het Centraal Station die snel willen itereren.
+
+---
+
+## Districts van Antwerpen die we ook bedienen
+
+We leveren in heel Antwerpen en plannen aparte pagina's voor elke deelgemeente. Tot die live staan, vind je updates op [de locaties-pagina](/locaties).
+
+- Berchem
+- Berendrecht-Zandvliet-Lillo
+- Borgerhout
+- Borsbeek
+- Deurne
+- Ekeren
+- Hoboken
+- Merksem
+- Wilrijk
+
+Heb je nu al een project in één van deze districten? Stuur je bestand mee; we houden rekening met levering en timing in jouw buurt.
+
+---
+
+## Veelgestelde vragen rond 3D printen in Antwerpen
+
+**Welke bestandsformaten accepteren jullie?**  
+STL of STEP werken het best. Voeg foto's of schetsen toe als de oriëntatie of zichtzijde belangrijk is.
+
+**Hoe snel krijg ik een offerte?**  
+Meestal binnen één werkdag. Vermeld aantallen, materiaalvoorkeur en gewenste leverdatum voor de haven of binnenstad.
+
+**Kan ik afhalen?**  
+Afhalen kan op afspraak in Herzele; verzending naar Antwerpen is standaard mogelijk volgens de [prijzen](/pricing).
+
+**Hebben jullie ervaring met technische onderdelen?**  
+Ja. We leveren regelmatig functionele onderdelen aan engineers en makers. Zie ook ons segment voor [engineers](/segments/3d-printing-engineers) en [makers](/segments/3d-printing-makers).
+
+---
+
+## Handige interne links voor Antwerpen
+
+- [Materialen & richtlijnen](/materials) – kies het juiste filament en zie afmetingen.
+- [Prijzen](/pricing) – transparant over formaat, materiaal en nabewerking.
+- [3D viewer](/viewer) – snel STL of STEP checken op oriëntatie en oppervlakte.
+- [Portfolio](/portfolio) – voorbeelden van prototypes en kleine series.
+- [Segmenten](/segments/3d-printing-engineers) – doorsturen naar engineering-teams.
+
+---
+
+## Vraag je offerte aan voor 3D printen in Antwerpen
+
+Klaar om te starten met je project in Antwerpen of één van de districten? Upload je model via [contact](/contact) en ontvang snel een voorstel. We helpen je van eerste prototype tot schaalbare serie, met een aanpak die even helder is als de skyline langs de Schelde.

--- a/lib/locations.ts
+++ b/lib/locations.ts
@@ -21,6 +21,19 @@ export const locations: Location[] = [
     metaDescription: "Laat je 3D-idee werkelijkheid worden in Aalst van prototypes tot kleine series, PLA, PETG en TPU beschikbaar. Vraag een offerte bij X3DPrints.",
   },
   {
+    slug: "3d-printen-in-antwerpen",
+    city: "Antwerpen",
+    relatedPhrases: [
+      "3D print service Antwerpen",
+      "rapid prototyping Antwerpen",
+      "3D printing bedrijf Antwerpen",
+      "3D printen haven Antwerpen",
+      "3D model laten printen Antwerpen",
+    ],
+    metaDescription:
+      "Professionele 3D prints in Antwerpen voor havenbedrijven, creatieve bureaus en onderwijs. PLA, PETG en TPU met snelle levering.",
+  },
+  {
     slug: "3d-printen-in-herzele",
     city: "Herzele",
     relatedPhrases: [


### PR DESCRIPTION
## Wat
- Antwerpen toegevoegd aan de locatiesdataset.
- Nieuwe lokale landingscopy voor 3D printen in Antwerpen met interne links en districtvermelding.

## Waarom
- Uitbreiding van de lokale SEO-landingspagina’s richting Antwerpen en de districten.

## Testplan
- [ ] Build OK
- [ ] Lint OK
- [ ] Lighthouse >= 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Metadata/OG/JSON-LD up-to-date
- [ ] Geen dode links/console errors


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691ecb57a11c83329ae68102a915af15)