### PR TITLE
Add Antwerpen district landing pages

### DIFF
--- a/content/locations/3d-printen-in-antwerpen.md
+++ b/content/locations/3d-printen-in-antwerpen.md
@@ -1,0 +1,94 @@
+# 3D printen in Antwerpen: van haven tot binnenstad
+
+Zoek je een betrouwbare partner voor **3D printen in Antwerpen**? X3DPrints staat klaar voor teams in de haven, bureaus aan het Eilandje, makers in Borgerhout en studenten rond de Universiteit Antwerpen. Vanuit onze studio in Herzele leveren we prototypes, kleine series en maatwerk onderdelen die klaar zijn voor de Scheldestad.
+
+Met onze **3D print service Antwerpen** krijg je snelle offertes, scherpe prijzen en duidelijke materiaalkeuzes. We denken mee over passing, oriëntatie en afwerking zodat je model meteen inzetbaar is – of je nu een maquette wilt voor een pitch aan de Meir, een functioneel onderdeel in de diamantwijk of een display voor een expo in het MAS.
+
+---
+
+## Waarom X3DPrints voor Antwerpen?
+
+- ⚡ **Snel geleverd**: meestal binnen enkele werkdagen verzonden of opgehaald.
+- 🎯 **Precisie**: strakke toleranties voor onderdelen die moeten passen in krappe ruimtes (handig voor installaties in het Havenhuis of labs op Campus Groenenborger).
+- 🌍 **Flexibel in materiaal**: PLA Matte voor zichtwerk, PETG voor stevige toepassingen in de haven, TPU voor flexibele onderdelen zoals bumpers of grips.
+- 🤝 **Persoonlijke aanpak**: korte lijnen, duidelijke communicatie en foto's tijdens productie als je dat wil.
+
+**Lokale touch:** we kennen de mix van industrie en creativiteit in Antwerpen. Denk aan scheepswerven en logistiek langs het Albertkanaal, expo's op het Eilandje, start-ups rond het station Antwerpen-Centraal en ambachtslui in het Zuid. Die variatie vraagt maatwerk; precies wat we bieden met onze **3D printing service Antwerpen**.
+
+---
+
+## Materialen voor projecten in Antwerpen
+
+| Materiaal     | Belangrijkste eigenschap       | Ideaal voor |
+| :------------ | :----------------------------- | :---------- |
+| **PLA Matte** | Strak en detailrijk, veel kleuren | Maquettes van het MAS, display props voor retail in de Stadsfeestzaal |
+| **PETG**      | Sterk en temperatuurbestendig    | Functionele onderdelen voor havenapparatuur of logistieke hulpmiddelen |
+| **TPU**       | Flexibel en schokdempend          | Beschermhoezen, bumpers voor flightcases, custom grips voor tools |
+
+*Tip:* wil je een behuizing voor sensoren aan de kaaien of een schaalmodel voor een pitch in het Designcenter De Winkelhaak? Kies PETG voor stevigheid en PLA voor maximale esthetiek. Twijfel je? Vraag materiaaladvies mee met je bestand via [contact](/contact).
+
+---
+
+## Voor wie in Antwerpen?
+
+### ⚓ Havenbedrijven & logistiek
+Reserveonderdelen, hulphulpmiddelen, custom mounts voor scanners of camera's – snel geleverd richting kaaien of magazijnen.
+
+### 🎨 Creatieve bureaus & musea
+Displays, props en maquettes voor expo's in het MAS, deSingel of het Letterenhuis. Combineer fijne details met een nette afwerking.
+
+### 🎓 Studenten & onderzoek
+Makers op Campus Paardenmarkt of Groenenborger krijgen snel prototypes voor projecten, thesis-onderzoek of robotica.
+
+### 🏢 Kmo's & start-ups
+Van proof-of-concept tot kleine serie. Ideaal voor hardware-teams in Berchem, Borgerhout of rond het Centraal Station die snel willen itereren.
+
+---
+
+## Districts van Antwerpen die we ook bedienen
+
+We leveren in heel Antwerpen en hebben aparte pagina's voor de districten. Zo krijg je meteen de juiste info per buurt.
+
+- [3D printen in Berchem](/3d-printen-in-berchem)
+- [3D printen in Berendrecht-Zandvliet-Lillo](/3d-printen-in-berendrecht-zandvliet-lillo)
+- [3D printen in Borgerhout](/3d-printen-in-borgerhout)
+- [3D printen in Borsbeek](/3d-printen-in-borsbeek)
+- [3D printen in Deurne](/3d-printen-in-deurne)
+- [3D printen in Ekeren](/3d-printen-in-ekeren)
+- [3D printen in Hoboken](/3d-printen-in-hoboken)
+- [3D printen in Merksem](/3d-printen-in-merksem)
+- [3D printen in Wilrijk](/3d-printen-in-wilrijk)
+
+Heb je nu al een project in één van deze districten? Stuur je bestand mee; we houden rekening met levering en timing in jouw buurt.
+
+---
+
+## Veelgestelde vragen rond 3D printen in Antwerpen
+
+**Welke bestandsformaten accepteren jullie?**  
+STL of STEP werken het best. Voeg foto's of schetsen toe als de oriëntatie of zichtzijde belangrijk is.
+
+**Hoe snel krijg ik een offerte?**  
+Meestal binnen één werkdag. Vermeld aantallen, materiaalvoorkeur en gewenste leverdatum voor de haven of binnenstad.
+
+**Kan ik afhalen?**  
+Afhalen kan op afspraak in Herzele; verzending naar Antwerpen is standaard mogelijk volgens de [prijzen](/pricing).
+
+**Hebben jullie ervaring met technische onderdelen?**  
+Ja. We leveren regelmatig functionele onderdelen aan engineers en makers. Zie ook ons segment voor [engineers](/segments/3d-printing-engineers) en [makers](/segments/3d-printing-makers).
+
+---
+
+## Handige interne links voor Antwerpen
+
+- [Materialen & richtlijnen](/materials) – kies het juiste filament en zie afmetingen.
+- [Prijzen](/pricing) – transparant over formaat, materiaal en nabewerking.
+- [3D viewer](/viewer) – snel STL of STEP checken op oriëntatie en oppervlakte.
+- [Portfolio](/portfolio) – voorbeelden van prototypes en kleine series.
+- [Segmenten](/segments/3d-printing-engineers) – doorsturen naar engineering-teams.
+
+---
+
+## Vraag je offerte aan voor 3D printen in Antwerpen
+
+Klaar om te starten met je project in Antwerpen of één van de districten? Upload je model via [contact](/contact) en ontvang snel een voorstel. We helpen je van eerste prototype tot schaalbare serie, met een aanpak die even helder is als de skyline langs de Schelde.

--- a/content/locations/3d-printen-in-berchem.md
+++ b/content/locations/3d-printen-in-berchem.md
@@ -1,0 +1,53 @@
+# 3D printen in Berchem: van Zurenborg tot Groenenhoek
+
+Zoek je een partner voor **3D printen in Berchem** die meedenkt met je ontwerp en snel levert? X3DPrints ondersteunt creatieven in Zurenborg, productteams rond het station Antwerpen-Berchem en makers in Groenenhoek. Met lokale kennis en een studio in Herzele leveren we prototypes en kleine series die klaar zijn voor pitch, expo of testopstelling.
+
+---
+
+## Waarom X3DPrints voor Berchem?
+
+- ⚡ **Snel schakelen**: korte doorlooptijden zodat je mock-up mee kan naar een meeting in de Cogels-Osylei of een klantgesprek aan de Singel.
+- 🎯 **Precisie en pasvorm**: ideaal voor behuizingen of klemmen die in bestaande toestellen moeten passen.
+- 🌿 **Afwerking op maat**: strak PLA Matte voor zichtwerk, PETG of TPU voor functionele delen in atelier of lab.
+- 🤝 **Transparante communicatie**: duidelijke prijzen en updates per milestone.
+
+**Lokale touch:** Berchem combineert herenhuizen, creatieve agencies en mobiliteitsknooppunten. We denken mee over de juiste materiaalkeuze voor prototypes richting Blue Gate Antwerp, displays in de winkelstraat Driekoningen of maquettes voor projecten in Zurenborg.
+
+---
+
+## Materiaalkeuze voor Berchemse projecten
+
+| Materiaal     | Pluspunt                      | Ideaal voor |
+| :------------ | :--------------------------- | :---------- |
+| **PLA Matte** | Strakke look, veel kleuren   | Maquettes van Zurenborg, presentaties voor vastgoed aan de Cogels-Osylei |
+| **PETG**      | Sterk en temperatuurbestendig | Functionele onderdelen voor mobiliteitsprojecten aan de Singel |
+| **TPU**       | Flexibel en schokdempend     | Beschermhoezen, grips of bumpers voor fieldtests in kantoren rond Berchem Station |
+
+---
+
+## Typische Berchemse noden
+
+- 🎨 **Agentschappen & studios**: props, displays of beursmateriaal voor events in Antwerp Expo.
+- 🏢 **Kmo's & scale-ups**: functionele onderdelen voor pilots in de buurt van het station of Post X.
+- 🛠 **Makers & studenten**: snelle iteraties voor projecten in FabLabs of scholen.
+
+---
+
+## Leveren of afhalen
+
+We verzenden dagelijks naar Berchem. Timing nodig voor een pitch? Vermeld de datum bij je aanvraag. Afhalen in Herzele kan op afspraak; verzending volgens [prijzen](/pricing).
+
+---
+
+## Interne links rond Antwerpen
+
+- [3D printen in Antwerpen](/3d-printen-in-antwerpen)
+- [3D printen in Borgerhout](/3d-printen-in-borgerhout)
+- [3D printen in Deurne](/3d-printen-in-deurne)
+- [3D printen in Wilrijk](/3d-printen-in-wilrijk)
+
+---
+
+## Offerte aanvragen voor 3D printen in Berchem
+
+Stuur je STL- of STEP-bestand via [contact](/contact) en vermeld kleur, aantal en gewenste leverdatum. Je ontvangt snel een voorstel zodat je project in Berchem zonder vertraging vooruitgaat.

--- a/content/locations/3d-printen-in-berendrecht-zandvliet-lillo.md
+++ b/content/locations/3d-printen-in-berendrecht-zandvliet-lillo.md
@@ -1,0 +1,53 @@
+# 3D printen in Berendrecht, Zandvliet en Lillo: klaar voor de haven
+
+Werk je in de polders of aan de Antwerpse haven en zoek je een betrouwbare partner voor **3D printen in Berendrecht-Zandvliet-Lillo**? X3DPrints levert stevige onderdelen en prototypes voor teams in de buurt van BASF, het Havencentrum of de historische dorpskern van Lillo. Reken op korte doorlooptijden en duidelijke communicatie.
+
+---
+
+## Waarom X3DPrints voor BZL?
+
+- ⚙️ **Functionele sterkte**: PETG en TPU voor onderdelen die tegen een stootje kunnen in werkplaatsen of op kades.
+- ⏱️ **Snelle levering**: vaak binnen enkele werkdagen verzonden richting Noorderlaan of Scheldelaan.
+- 🧭 **Projectbegeleiding**: advies over oriëntatie en laaghoogte zodat onderdelen passen in bestaande installaties.
+- 🤝 **Heldere prijzen**: transparant over kost en lead time, zonder verrassingen.
+
+**Lokale touch:** we kennen de mix van zware industrie en dorpsgevoel rond het Fort van Lillo. Of je nu een bracket nodig hebt voor meetapparatuur, een behuizing voor sensoren of een schaalmodel voor het Havencentrum, we stemmen materiaal en afwerking af op de omgeving.
+
+---
+
+## Materialen voor havenprojecten
+
+| Materiaal     | Pluspunt                        | Ideaal voor |
+| :------------ | :----------------------------- | :---------- |
+| **PETG**      | Chemisch en temperatuurvast    | Behuizingen of klemmen in industriële installaties |
+| **TPU**       | Flexibel en schokdempend       | Dempers, grips of beschermhoezen voor veldwerk |
+| **PLA Matte** | Strak detail voor zichtwerk    | Maquettes van het Havenhuis of visuals voor opleidingen |
+
+---
+
+## Toepassingen in BZL
+
+- 🏭 **Industrie & maintenance**: snelle vervangstukken voor installaties langs de Scheldelaan.
+- 📡 **Meet- en sensorteams**: custom behuizingen die buiten kunnen staan.
+- 🧑‍🏫 **Educatie & bezoekerscentra**: maquettes en interactieve onderdelen voor het Havencentrum of rondleidingen in Lillo.
+
+---
+
+## Logistiek
+
+We versturen dagelijks richting de noordelijke districten. Spoed nodig? Vermeld het in je aanvraag, dan plannen we productie en verzending in lijn met je deadline. Afhalen in Herzele kan op afspraak.
+
+---
+
+## Interne links rond Antwerpen
+
+- [3D printen in Antwerpen](/3d-printen-in-antwerpen)
+- [3D printen in Ekeren](/3d-printen-in-ekeren)
+- [3D printen in Merksem](/3d-printen-in-merksem)
+- [3D printen in Hoboken](/3d-printen-in-hoboken)
+
+---
+
+## Start je aanvraag
+
+Upload je STL- of STEP-bestand via [contact](/contact). Voeg aantallen en materiaalvoorkeur toe; we bezorgen snel een voorstel voor je project in Berendrecht, Zandvliet of Lillo.

--- a/content/locations/3d-printen-in-borgerhout.md
+++ b/content/locations/3d-printen-in-borgerhout.md
@@ -1,0 +1,53 @@
+# 3D printen in Borgerhout: creatief langs de Turnhoutsebaan
+
+Wil je snel en scherp **3D printen in Borgerhout**? X3DPrints helpt bureaus, makers en organisaties rond de Turnhoutsebaan, De Roma en Spoor Oost met prototypes en kleine series. Van custom displays tot functionele onderdelen: we leveren snel, met advies op maat.
+
+---
+
+## Waarom kiezen voor X3DPrints?
+
+- 🚀 **Snelle doorlooptijd**: vaak binnen enkele werkdagen klaar voor je klantmeeting of expo.
+- 🎯 **Detail en pasvorm**: ideaal voor zichtwerk én onderdelen die in bestaande toestellen moeten klikken.
+- 🧩 **Flexibele materialen**: PLA Matte voor strakke prints, PETG voor stevige toepassingen, TPU voor flexibele grips of bumpers.
+- 🤝 **Heldere communicatie**: duidelijke offertes, updates tijdens productie en fotoreports indien gewenst.
+
+**Lokale touch:** Borgerhout bruist van cultuur en ondernemerschap. Denk aan een prop voor een voorstelling in De Roma, een maquette voor een project op Spoor Oost of een behuizing voor electronics in een atelier in het Krugerplein. We stemmen de afwerking af op jouw toepassing.
+
+---
+
+## Materialen voor Borgerhout
+
+| Materiaal     | Pluspunt                      | Ideaal voor |
+| :------------ | :--------------------------- | :---------- |
+| **PLA Matte** | Mooie afwerking, veel kleuren | Displays, props en maquettes voor expo's of presentaties |
+| **PETG**      | Stevig en hittebestendig      | Functionele onderdelen voor prototypes of reparaties |
+| **TPU**       | Flexibel en duurzaam          | Bescherming voor elektronica, grips voor tools in ateliers |
+
+---
+
+## Typische projecten
+
+- 🎭 **Cultuurhuizen**: rekwisieten en decor voor De Roma of buurtpodiums.
+- 🛠 **Makers & repair cafés**: vervangstukken en custom mounts voor apparatuur.
+- 🏪 **Retail & horeca**: unieke displays of signage langs de Turnhoutsebaan.
+
+---
+
+## Levering
+
+We verzenden dagelijks naar Borgerhout. Geef je deadline door, dan plannen we mee. Afhalen in Herzele kan op afspraak; verzending volgens [prijzen](/pricing).
+
+---
+
+## Interne links rond Antwerpen
+
+- [3D printen in Antwerpen](/3d-printen-in-antwerpen)
+- [3D printen in Berchem](/3d-printen-in-berchem)
+- [3D printen in Deurne](/3d-printen-in-deurne)
+- [3D printen in Merksem](/3d-printen-in-merksem)
+
+---
+
+## Vraag je offerte aan
+
+Upload je STL- of STEP-bestand via [contact](/contact). Vermeld materiaal, kleur en aantal; we bezorgen snel een voorstel voor **3D printen in Borgerhout**.

--- a/content/locations/3d-printen-in-borsbeek.md
+++ b/content/locations/3d-printen-in-borsbeek.md
@@ -1,0 +1,53 @@
+# 3D printen in Borsbeek: dichtbij luchthaven en Fort 3
+
+Op zoek naar **3D printen in Borsbeek** voor prototypes of kleine series? X3DPrints levert nauwkeurige onderdelen voor teams rond Fort 3, bedrijven nabij de luchthaven en makers in het centrum. We denken mee over materiaal, afwerking en levertijd zodat je snel verder kan.
+
+---
+
+## Waarom X3DPrints voor Borsbeek?
+
+- ⚡ **Korte lead times**: meestal binnen enkele werkdagen verzonden richting Borsbeek of Antwerpen Airport.
+- 🎯 **Precisie**: scherpe toleranties voor onderdelen die moeten passen in meetapparatuur of behuizingen.
+- 🧪 **Materiaaladvies**: PLA Matte voor zichtwerk, PETG voor hittebestendige stukken, TPU voor flexibele onderdelen.
+- 🤝 **Heldere communicatie**: transparante offertes en updates tijdens productie.
+
+**Lokale touch:** van luchtvaart-gerelateerde prototypes tot educatieve modellen voor lokale scholen: we kennen de noden in en rond Borsbeek en stemmen onze **3D print service** daarop af.
+
+---
+
+## Materiaaloverzicht
+
+| Materiaal     | Pluspunt                    | Ideaal voor |
+| :------------ | :------------------------- | :---------- |
+| **PLA Matte** | Strakke look, veel kleuren | Maquettes of displays voor presentaties in Fort 3 |
+| **PETG**      | Sterk en temperatuurvast   | Functionele onderdelen voor tools of drones nabij de luchthaven |
+| **TPU**       | Flexibel en slijtvast      | Beschermhoezen, bumpers of custom grips |
+
+---
+
+## Toepassingen in Borsbeek
+
+- 🛫 **Luchtvaart & logistiek**: brackets of testbehuizingen voor sensoren rond de luchthaven.
+- 🏫 **Onderwijs**: models en prototypes voor scholen of STEM-projecten.
+- 🏪 **Retail & events**: displays of gepersonaliseerde gadgets voor lokale winkels.
+
+---
+
+## Levering en timing
+
+We versturen dagelijks naar Borsbeek. Geef een deadline mee als je iets nodig hebt voor een demo of expo; we plannen de productie hierop. Afhalen kan op afspraak in Herzele.
+
+---
+
+## Interne links rond Antwerpen
+
+- [3D printen in Antwerpen](/3d-printen-in-antwerpen)
+- [3D printen in Deurne](/3d-printen-in-deurne)
+- [3D printen in Berchem](/3d-printen-in-berchem)
+- [3D printen in Wilrijk](/3d-printen-in-wilrijk)
+
+---
+
+## Offerte voor 3D printen in Borsbeek
+
+Upload je STL- of STEP-bestand via [contact](/contact). Vermeld aantallen en materiaalkeuze; we sturen snel een voorstel zodat je project in Borsbeek vooruitgaat.

--- a/content/locations/3d-printen-in-deurne.md
+++ b/content/locations/3d-printen-in-deurne.md
@@ -1,0 +1,53 @@
+# 3D printen in Deurne: dicht bij Rivierenhof en luchthaven
+
+Zoek je een vlotte partner voor **3D printen in Deurne**? X3DPrints ondersteunt teams rond het Rivierenhof, Sportpaleis/Lotto Arena en Antwerp Airport met prototypes, maquettes en functionele onderdelen. We leveren snel, met helder advies en transparante prijzen.
+
+---
+
+## Waarom X3DPrints voor Deurne?
+
+- ⚡ **Snel klaar**: vaak binnen enkele werkdagen verzonden naar Deurne.
+- 🎯 **Nauwkeurig**: perfecte pasvorm voor onderdelen in toestellen of montagekits.
+- 🌿 **Afwerking op maat**: PLA Matte voor zichtwerk, PETG voor robuuste toepassingen, TPU voor flexibele elementen.
+- 🤝 **Transparant**: duidelijke offertes en updates per stap.
+
+**Lokale touch:** van een maquette voor een event in het Rivierenhof tot een behuizing voor sensoren nabij de luchthaven: we kennen de mix van groen, events en industrie in Deurne en passen onze **3D print service** daarop aan.
+
+---
+
+## Materialen
+
+| Materiaal     | Pluspunt                     | Ideaal voor |
+| :------------ | :-------------------------- | :---------- |
+| **PLA Matte** | Strak detail, veel kleuren  | Presentaties, prototypes of decor voor evenementen |
+| **PETG**      | Stevig en temperatuurbestendig | Functionele onderdelen voor apparaten of testopstellingen |
+| **TPU**       | Flexibel en schokbestendig  | Beschermhoezen of grips voor gereedschap |
+
+---
+
+## Toepassingen in Deurne
+
+- 🎶 **Events & beurzen**: props of displays voor shows in Sportpaleis en Lotto Arena.
+- 🏭 **Kmo's & techniek**: op maat gemaakte onderdelen voor machines en pilots.
+- 🎓 **Onderwijs & hobby**: prototypes en maquettes voor scholen of makers.
+
+---
+
+## Levering
+
+Dagelijkse verzending naar Deurne. Deadline? Vermeld datum en locatie, dan plannen we productie en levering. Afhalen in Herzele kan na afspraak.
+
+---
+
+## Interne links rond Antwerpen
+
+- [3D printen in Antwerpen](/3d-printen-in-antwerpen)
+- [3D printen in Borgerhout](/3d-printen-in-borgerhout)
+- [3D printen in Borsbeek](/3d-printen-in-borsbeek)
+- [3D printen in Merksem](/3d-printen-in-merksem)
+
+---
+
+## Start nu
+
+Upload je STL- of STEP-bestand via [contact](/contact). Vermeld materiaal, kleur en deadline; we bezorgen snel een helder voorstel voor **3D printen in Deurne**.

--- a/content/locations/3d-printen-in-ekeren.md
+++ b/content/locations/3d-printen-in-ekeren.md
@@ -1,0 +1,53 @@
+# 3D printen in Ekeren: tussen Veltwijckpark en haven
+
+Heb je **3D printen in Ekeren** nodig voor prototypes, tools of maquettes? X3DPrints ondersteunt bedrijven rond het Veltwijckpark, de A12 en de nabijgelegen havenzones. We leveren snel en helpen je kiezen tussen PLA, PETG of TPU.
+
+---
+
+## Waarom X3DPrints voor Ekeren?
+
+- ⚡ **Snelle service**: korte lead times richting Ekeren en omgeving.
+- 🎯 **Precisie**: strakke toleranties voor onderdelen die direct moeten passen.
+- 🧪 **Materiaaladvies**: van zichtwerk tot stevige industriële onderdelen.
+- 🤝 **Heldere updates**: transparante offertes en voortgangsfoto's indien gewenst.
+
+**Lokale touch:** Ekeren balanceert wonen, industrie en logistiek. Denk aan een behuizing voor een sensorkast in de haven, een maquette voor een project rond Veltwijckpark of een custom mount voor een testopstelling langs de A12. We stemmen de print daarop af.
+
+---
+
+## Materiaalopties
+
+| Materiaal     | Pluspunt                      | Ideaal voor |
+| :------------ | :--------------------------- | :---------- |
+| **PLA Matte** | Strakke look, detailrijk     | Maquettes en visuals voor pitches |
+| **PETG**      | Sterk en temperatuurvast     | Functionele onderdelen in industriële omgevingen |
+| **TPU**       | Flexibel en schokdempend     | Beschermhoezen, afdichtingen en grips |
+
+---
+
+## Toepassingen in Ekeren
+
+- 🏭 **Industrie & logistiek**: vervangstukken en hulpmiddelen voor teams langs de haven.
+- 🏢 **Kmo's & bureaus**: prototypes voor klantpresentaties of pilots.
+- 🌳 **Publieke projecten**: maquettes voor park- of infrastructuurdossiers.
+
+---
+
+## Levering
+
+Dagelijkse verzending naar Ekeren. Spoedproject? Geef je deadline mee; we plannen accordingly. Afhalen in Herzele kan na afspraak.
+
+---
+
+## Interne links rond Antwerpen
+
+- [3D printen in Antwerpen](/3d-printen-in-antwerpen)
+- [3D printen in Berendrecht-Zandvliet-Lillo](/3d-printen-in-berendrecht-zandvliet-lillo)
+- [3D printen in Merksem](/3d-printen-in-merksem)
+- [3D printen in Hoboken](/3d-printen-in-hoboken)
+
+---
+
+## Offerte aanvragen
+
+Upload je STL- of STEP-bestand via [contact](/contact). Vermeld materiaal, kleur en aantal; je krijgt snel een voorstel voor **3D printen in Ekeren**.

--- a/content/locations/3d-printen-in-hoboken.md
+++ b/content/locations/3d-printen-in-hoboken.md
@@ -1,0 +1,53 @@
+# 3D printen in Hoboken: tussen Schelde en Blue Gate Antwerp
+
+Heb je **3D printen in Hoboken** nodig voor prototypes, tools of displays? X3DPrints helpt teams in de buurt van Blue Gate Antwerp, de Schelde en de woonkernen van Hoboken. Reken op duidelijke prijzen, snelle levering en materiaaladvies op maat.
+
+---
+
+## Waarom X3DPrints?
+
+- ⚡ **Snel geleverd**: vaak binnen enkele werkdagen richting Hoboken.
+- 🎯 **Precisie**: strakke toleranties voor onderdelen die direct moeten passen.
+- 🌍 **Materiaalkeuze**: PLA Matte voor zichtwerk, PETG voor stevige toepassingen, TPU voor flexibele delen.
+- 🤝 **Duidelijke communicatie**: transparant over lead time en opties.
+
+**Lokale touch:** of het nu gaat om een behuizing voor sensoren in de scheepswerf, een maquette voor een project aan de Schelde of een display voor een stand in Blue Gate Antwerp: we stemmen afwerking en materiaal op jouw gebruik.
+
+---
+
+## Materialen
+
+| Materiaal     | Pluspunt                       | Ideaal voor |
+| :------------ | :---------------------------- | :---------- |
+| **PLA Matte** | Strak detail, veel kleuren    | Maquettes en presentaties voor projecten langs de Schelde |
+| **PETG**      | Sterk en temperatuurvast      | Functionele onderdelen voor werkplaatsen of labs |
+| **TPU**       | Flexibel en schokdempend      | Beschermhoezen, dempers of kabelklemmen |
+
+---
+
+## Toepassingen in Hoboken
+
+- 🏭 **Industrie & scheepsbouw**: custom mounts en vervangstukken voor werkplaatsen.
+- 🌱 **Innovatie in Blue Gate**: prototypes voor cleantech en circulaire projecten.
+- 🏪 **Retail & events**: displays of branded gadgets voor lokale zaken.
+
+---
+
+## Logistiek
+
+Dagelijkse verzending naar Hoboken. Deadline voor een demo? Vermeld het in je aanvraag; we plannen productie en levering. Afhalen in Herzele kan na afspraak.
+
+---
+
+## Interne links rond Antwerpen
+
+- [3D printen in Antwerpen](/3d-printen-in-antwerpen)
+- [3D printen in Ekeren](/3d-printen-in-ekeren)
+- [3D printen in Merksem](/3d-printen-in-merksem)
+- [3D printen in Wilrijk](/3d-printen-in-wilrijk)
+
+---
+
+## Vraag je offerte aan
+
+Upload je STL- of STEP-bestand via [contact](/contact). Vermeld materiaal en deadline; we bezorgen snel een voorstel voor **3D printen in Hoboken**.

--- a/content/locations/3d-printen-in-merksem.md
+++ b/content/locations/3d-printen-in-merksem.md
@@ -1,0 +1,53 @@
+# 3D printen in Merksem: dichtbij Sportpaleis en havens
+
+Op zoek naar **3D printen in Merksem**? X3DPrints helpt bedrijven en makers rond het Sportpaleis, de Bredabaan en de noordelijke havenzones. We leveren snel prototypes, vervangstukken en displays met materiaalkeuze op maat.
+
+---
+
+## Waarom X3DPrints voor Merksem?
+
+- ⚡ **Korte doorlooptijd**: vaak binnen enkele werkdagen verzonden naar Merksem.
+- 🎯 **Nauwkeurige pasvorm**: ideaal voor onderdelen die in bestaande installaties moeten klikken.
+- 🧪 **Materiaaladvies**: PLA Matte voor zichtwerk, PETG voor robuuste toepassingen, TPU voor flexibele of schokdempende onderdelen.
+- 🤝 **Transparant**: duidelijke offertes en updates.
+
+**Lokale touch:** of het nu een display is voor een event in het Sportpaleis, een behuizing voor sensoren langs de haven of een custom jig voor een werkplaats aan de Bredabaan: we stemmen de print af op je gebruik.
+
+---
+
+## Materialen
+
+| Materiaal     | Pluspunt                     | Ideaal voor |
+| :------------ | :-------------------------- | :---------- |
+| **PLA Matte** | Strak detail, veel kleuren  | Maquettes en presentaties |
+| **PETG**      | Stevig en temperatuurvast   | Functionele onderdelen voor machines of logistiek |
+| **TPU**       | Flexibel en slijtvast       | Beschermhoezen, dempers of kabelklemmen |
+
+---
+
+## Toepassingen in Merksem
+
+- 🎶 **Events**: props en displays voor Sportpaleis of Lotto Arena.
+- 🏭 **Industrie & logistiek**: vervangstukken en hulpmiddelen langs de haven.
+- 🛠 **Makers & repair**: custom mounts of adapters voor ateliers.
+
+---
+
+## Levering
+
+Dagelijkse verzending naar Merksem. Spoed nodig? Vermeld je deadline; we plannen productie en levering. Afhalen in Herzele kan na afspraak.
+
+---
+
+## Interne links rond Antwerpen
+
+- [3D printen in Antwerpen](/3d-printen-in-antwerpen)
+- [3D printen in Berendrecht-Zandvliet-Lillo](/3d-printen-in-berendrecht-zandvliet-lillo)
+- [3D printen in Borgerhout](/3d-printen-in-borgerhout)
+- [3D printen in Hoboken](/3d-printen-in-hoboken)
+
+---
+
+## Offerte aanvragen
+
+Upload je STL- of STEP-bestand via [contact](/contact). Vermeld materiaal en aantallen; je ontvangt snel een voorstel voor **3D printen in Merksem**.

--- a/content/locations/3d-printen-in-wilrijk.md
+++ b/content/locations/3d-printen-in-wilrijk.md
@@ -1,0 +1,53 @@
+# 3D printen in Wilrijk: campus, bedrijven en Nachtegalenpark
+
+Voor **3D printen in Wilrijk** helpt X3DPrints bedrijven rond de UA-campus Drie Eiken, het Nachtegalenpark en de bedrijvenzones langs de A12. We leveren snelle prototypes, behuizingen en displays met advies op maat.
+
+---
+
+## Waarom X3DPrints voor Wilrijk?
+
+- ⚡ **Snel geleverd**: vaak binnen enkele werkdagen richting Wilrijk.
+- 🎯 **Nauwkeurig**: perfecte pasvorm voor onderdelen in testopstellingen of producten.
+- 🌿 **Afwerking naar keuze**: PLA Matte voor zichtwerk, PETG voor stevige onderdelen, TPU voor flexibele of dempende stukken.
+- 🤝 **Heldere communicatie**: transparante prijzen en updates tijdens productie.
+
+**Lokale touch:** denk aan een prototype voor een spin-off op Campus Drie Eiken, een maquette voor een project rond het Nachtegalenpark of een custom fixture voor een bedrijf langs de A12. We stemmen materiaal en oriëntatie af op je toepassing.
+
+---
+
+## Materiaalopties
+
+| Materiaal     | Pluspunt                     | Ideaal voor |
+| :------------ | :-------------------------- | :---------- |
+| **PLA Matte** | Strakke look, veel kleuren  | Maquettes en presentaties |
+| **PETG**      | Sterk en temperatuurvast    | Functionele onderdelen voor labs of productie |
+| **TPU**       | Flexibel en slijtvast       | Beschermhoezen, grips of dempers |
+
+---
+
+## Toepassingen in Wilrijk
+
+- 🎓 **Onderzoek & onderwijs**: prototypes voor universitaire labs.
+- 🏭 **Kmo's & productie**: custom tooling en vervangstukken.
+- 🌳 **Publieke projecten**: maquettes voor park- of mobiliteitsdossiers.
+
+---
+
+## Levering
+
+Dagelijkse verzending naar Wilrijk. Heb je een deadline? Vermeld datum en toepassing; we plannen productie en transport. Afhalen in Herzele kan na afspraak.
+
+---
+
+## Interne links rond Antwerpen
+
+- [3D printen in Antwerpen](/3d-printen-in-antwerpen)
+- [3D printen in Berchem](/3d-printen-in-berchem)
+- [3D printen in Hoboken](/3d-printen-in-hoboken)
+- [3D printen in Borsbeek](/3d-printen-in-borsbeek)
+
+---
+
+## Offerte aanvragen
+
+Upload je STL- of STEP-bestand via [contact](/contact). Vermeld materiaal en aantallen; je krijgt snel een voorstel voor **3D printen in Wilrijk**.

--- a/lib/locations.ts
+++ b/lib/locations.ts
@@ -21,6 +21,136 @@ export const locations: Location[] = [
     metaDescription: "Laat je 3D-idee werkelijkheid worden in Aalst van prototypes tot kleine series, PLA, PETG en TPU beschikbaar. Vraag een offerte bij X3DPrints.",
   },
   {
+    slug: "3d-printen-in-antwerpen",
+    city: "Antwerpen",
+    relatedPhrases: [
+      "3D print service Antwerpen",
+      "rapid prototyping Antwerpen",
+      "3D printing bedrijf Antwerpen",
+      "3D printen haven Antwerpen",
+      "3D model laten printen Antwerpen",
+    ],
+    metaDescription:
+      "Professionele 3D prints in Antwerpen voor havenbedrijven, creatieve bureaus en onderwijs. PLA, PETG en TPU met snelle levering.",
+  },
+  {
+    slug: "3d-printen-in-berchem",
+    city: "Berchem",
+    relatedPhrases: [
+      "3D print service Berchem",
+      "rapid prototyping Berchem",
+      "3D printing bedrijf Berchem",
+      "3D printen nabij Berchem",
+      "3D model laten printen Berchem",
+    ],
+    metaDescription:
+      "3D printen in Berchem met snelle levering richting Zurenborg en het station. PLA, PETG en TPU op maat van jouw prototype of serie.",
+  },
+  {
+    slug: "3d-printen-in-berendrecht-zandvliet-lillo",
+    city: "Berendrecht-Zandvliet-Lillo",
+    relatedPhrases: [
+      "3D print service Berendrecht",
+      "3D printen Zandvliet",
+      "3D printing bedrijf Lillo",
+      "rapid prototyping BZL",
+      "3D model laten printen Berendrecht-Zandvliet-Lillo",
+    ],
+    metaDescription:
+      "Stevige 3D prints voor Berendrecht, Zandvliet en Lillo met focus op havenprojecten. Kies PLA, PETG of TPU en ontvang snel een offerte.",
+  },
+  {
+    slug: "3d-printen-in-borgerhout",
+    city: "Borgerhout",
+    relatedPhrases: [
+      "3D print service Borgerhout",
+      "rapid prototyping Borgerhout",
+      "3D printing bedrijf Borgerhout",
+      "3D printen nabij Borgerhout",
+      "3D model laten printen Borgerhout",
+    ],
+    metaDescription:
+      "3D printen in Borgerhout met snelle levering voor Turnhoutsebaan, De Roma en Spoor Oost. Materialen PLA, PETG en TPU beschikbaar.",
+  },
+  {
+    slug: "3d-printen-in-borsbeek",
+    city: "Borsbeek",
+    relatedPhrases: [
+      "3D print service Borsbeek",
+      "rapid prototyping Borsbeek",
+      "3D printing bedrijf Borsbeek",
+      "3D printen nabij Borsbeek",
+      "3D model laten printen Borsbeek",
+    ],
+    metaDescription:
+      "Scherpe 3D prints in Borsbeek met snelle verzending richting Fort 3 en luchthaven. PLA Matte, PETG en TPU voor prototypes en onderdelen.",
+  },
+  {
+    slug: "3d-printen-in-deurne",
+    city: "Deurne",
+    relatedPhrases: [
+      "3D print service Deurne",
+      "rapid prototyping Deurne",
+      "3D printing bedrijf Deurne",
+      "3D printen nabij Deurne",
+      "3D model laten printen Deurne",
+    ],
+    metaDescription:
+      "3D printen in Deurne voor projecten rond Rivierenhof en Sportpaleis. Snelle offertes en levering in PLA, PETG of TPU.",
+  },
+  {
+    slug: "3d-printen-in-ekeren",
+    city: "Ekeren",
+    relatedPhrases: [
+      "3D print service Ekeren",
+      "rapid prototyping Ekeren",
+      "3D printing bedrijf Ekeren",
+      "3D printen nabij Ekeren",
+      "3D model laten printen Ekeren",
+    ],
+    metaDescription:
+      "3D print service in Ekeren met focus op industrie en haven. Kies PLA, PETG of TPU en ontvang snel een voorstel.",
+  },
+  {
+    slug: "3d-printen-in-hoboken",
+    city: "Hoboken",
+    relatedPhrases: [
+      "3D print service Hoboken",
+      "rapid prototyping Hoboken",
+      "3D printing bedrijf Hoboken",
+      "3D printen nabij Hoboken",
+      "3D model laten printen Hoboken",
+    ],
+    metaDescription:
+      "Professionele 3D prints in Hoboken voor Blue Gate en Scheldeprojecten. PLA, PETG en TPU met snelle levering.",
+  },
+  {
+    slug: "3d-printen-in-merksem",
+    city: "Merksem",
+    relatedPhrases: [
+      "3D print service Merksem",
+      "rapid prototyping Merksem",
+      "3D printing bedrijf Merksem",
+      "3D printen nabij Merksem",
+      "3D model laten printen Merksem",
+    ],
+    metaDescription:
+      "3D prints in Merksem met snelle doorlooptijd voor Bredabaan en Sportpaleis. PLA, PETG en TPU beschikbaar.",
+  },
+  {
+    slug: "3d-printen-in-wilrijk",
+    city: "Wilrijk",
+    relatedPhrases: [
+      "3D print service Wilrijk",
+      "rapid prototyping Wilrijk",
+      "3D printing bedrijf Wilrijk",
+      "3D printen nabij Wilrijk",
+      "3D model laten printen Wilrijk",
+    ],
+    metaDescription:
+      "Snelle 3D print service in Wilrijk voor campus Drie Eiken en bedrijven langs de A12. Materialen PLA, PETG en TPU.",
+  },
+  {
     slug: "3d-printen-in-herzele",
     city: "Herzele",
     relatedPhrases: [


### PR DESCRIPTION
## Wat
- Nieuwe lokale landingspagina’s voor Antwerpen-districten: Berchem, Berendrecht-Zandvliet-Lillo, Borgerhout, Borsbeek, Deurne, Ekeren, Hoboken, Merksem en Wilrijk.
- Antwerpen-hoofdpagina geüpdatet met interne links naar de districtspagina’s.
- Locatiesdataset uitgebreid met alle nieuwe slugs, zoektermen en meta descriptions.

## Waarom
- Uitbreiding van de lokale SEO-landingspagina’s richting Antwerpen en haar districten.

## Testplan
- [ ] Build OK
- [ ] Lint OK
- [ ] Lighthouse >= 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Metadata/OG/JSON-LD up-to-date
- [ ] Geen dode links/console errors


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691ecb57a11c83329ae68102a915af15)