### PR TITLE
Add Antwerp perimeter landing pages

### DIFF
--- a/content/locations/3d-printen-in-aartselaar.md
+++ b/content/locations/3d-printen-in-aartselaar.md
@@ -1,0 +1,32 @@
+# 3D printen in Aartselaar: snel en functioneel
+
+Voor **3D printen in Aartselaar** leveren we onderdelen en prototypes richting industriezone Cleydael en de A12. Je krijgt transparante prijzen en prints die meteen inzetbaar zijn.
+
+---
+
+## Pluspunten
+- ⚡ **Snel**: offerte binnen een werkdag, levering in enkele werkdagen.
+- 🧱 **Materiaalkeuze**: PLA Matte voor zichtwerk, PETG voor sterkte, TPU voor flexibele delen.
+- 🧭 **Meedenken**: advies over passing, oriëntatie en post-processing.
+
+---
+
+## Ideaal voor
+- **KMO's langs de A12**: jigs, klemmen en reserveonderdelen.
+- **Engineering & R&D**: prototypes voor tests en validatie.
+- **Marketing & events**: displays en props die opvallen.
+
+---
+
+## Zo bestel je
+- Upload **STL/STEP** via [contact](/contact) met aantallen en materiaal.
+- Tot **25 × 25 × 25 cm** per onderdeel; grotere stukken delen we netjes op.
+- Verzending of afhalen; prijzen staan op [pricing](/pricing).
+
+---
+
+## Interne links
+- [3D printen in Kontich](/3d-printen-in-kontich)
+- [3D printen in Boom](/3d-printen-in-boom)
+- [3D printen in Rumst](/3d-printen-in-rumst)
+- [3D printen in Antwerpen](/3d-printen-in-antwerpen)

--- a/content/locations/3d-printen-in-antwerpen.md
+++ b/content/locations/3d-printen-in-antwerpen.md
@@ -59,6 +59,25 @@ We leveren in heel Antwerpen en hebben aparte pagina's voor de districten. Zo kr
 - [3D printen in Merksem](/3d-printen-in-merksem)
 - [3D printen in Wilrijk](/3d-printen-in-wilrijk)
 
+### 🌆 Rand rond Antwerpen die je nog kan coveren
+Voor fijnmazige SEO en hyperlokale intent kun je de randgemeenten mee opnemen. Suggesties:
+
+- [3D printen in Mortsel](/3d-printen-in-mortsel)
+- [3D printen in Edegem](/3d-printen-in-edegem)
+- [3D printen in Kontich](/3d-printen-in-kontich)
+- [3D printen in Aartselaar](/3d-printen-in-aartselaar)
+- [3D printen in Wommelgem](/3d-printen-in-wommelgem)
+- [3D printen in Wijnegem](/3d-printen-in-wijnegem)
+- [3D printen in Schilde](/3d-printen-in-schilde)
+- [3D printen in Schoten](/3d-printen-in-schoten)
+- [3D printen in Brasschaat](/3d-printen-in-brasschaat)
+- [3D printen in Kapellen](/3d-printen-in-kapellen)
+- [3D printen in Hove](/3d-printen-in-hove)
+- [3D printen in Lint](/3d-printen-in-lint)
+- [3D printen in Boechout](/3d-printen-in-boechout)
+- [3D printen in Boom](/3d-printen-in-boom)
+- [3D printen in Rumst](/3d-printen-in-rumst)
+
 Heb je nu al een project in één van deze districten? Stuur je bestand mee; we houden rekening met levering en timing in jouw buurt.
 
 ---

--- a/content/locations/3d-printen-in-boechout.md
+++ b/content/locations/3d-printen-in-boechout.md
@@ -1,0 +1,32 @@
+# 3D printen in Boechout: snel en helder
+
+Voor **3D printen in Boechout** leveren we prototypes en onderdelen richting Vremde, Spoor Oost en de dorpskern. Je krijgt duidelijke prijzen en prints die netjes afgewerkt zijn.
+
+---
+
+## Waarom X3DPrints
+- ⚡ **Snel**: offerte binnen een dag, levering in enkele werkdagen.
+- 🎯 **Afgewerkt**: PLA Matte voor zichtwerk, PETG voor stevige onderdelen, TPU voor flexibele stukken.
+- 🧭 **Meedenken**: advies over oriëntatie en afwerking zodat alles past.
+
+---
+
+## Voor wie
+- **Lokale ondernemers en makers**: props, houders, kleine series.
+- **Events en expo's**: displays en maquettes die opvallen.
+- **Onderwijs**: modellen voor STEM en proefopstellingen.
+
+---
+
+## Bestellen
+- Upload **STL/STEP** via [contact](/contact) met aantallen en materiaalvoorkeur.
+- Tot **25 × 25 × 25 cm** per stuk; grotere onderdelen splitsen we.
+- Verzending of afhalen; bekijk [pricing](/pricing).
+
+---
+
+## Interne links
+- [3D printen in Mortsel](/3d-printen-in-mortsel)
+- [3D printen in Lint](/3d-printen-in-lint)
+- [3D printen in Antwerpen](/3d-printen-in-antwerpen)
+- [Materialen & richtlijnen](/materials)

--- a/content/locations/3d-printen-in-boom.md
+++ b/content/locations/3d-printen-in-boom.md
@@ -1,0 +1,32 @@
+# 3D printen in Boom: klaar voor events en industrie
+
+Zoek je **3D printen in Boom** voor projecten rond De Schorre, de Rupel of industrie langs de A12? Wij leveren snel prototypes en onderdelen met heldere prijzen.
+
+---
+
+## Waarom X3DPrints
+- ⚡ **Tempo**: offerte binnen een dag, levering in enkele werkdagen.
+- 🧱 **Materiaalselectie**: PLA Matte voor zichtwerk, PETG voor stevige onderdelen, TPU voor flexibele stukken.
+- 🧭 **Advies** over passing, oriëntatie en nabewerking.
+
+---
+
+## Toepassingen
+- **Events & expo's**: props, houders en displays voor festivals en beurzen.
+- **KMO's langs de A12**: jigs, klemmen en functionele onderdelen.
+- **Makers**: kleine series en prototypes voor testen.
+
+---
+
+## Bestellen
+- Upload **STL/STEP** via [contact](/contact) met aantallen en materiaal.
+- Max. **25 × 25 × 25 cm** per onderdeel; grotere delen splitsen we.
+- Verzending richting Boom of afhalen; tarieven op [pricing](/pricing).
+
+---
+
+## Interne links
+- [3D printen in Rumst](/3d-printen-in-rumst)
+- [3D printen in Aartselaar](/3d-printen-in-aartselaar)
+- [3D printen in Antwerpen](/3d-printen-in-antwerpen)
+- [Materialen & richtlijnen](/materials)

--- a/content/locations/3d-printen-in-brasschaat.md
+++ b/content/locations/3d-printen-in-brasschaat.md
@@ -1,0 +1,32 @@
+# 3D printen in Brasschaat: strak werk in het groen
+
+Voor **3D printen in Brasschaat** leveren we prototypes en onderdelen richting de Bredabaan, bedrijventerreinen en creatieve ateliers. Verwacht scherpe details, snelle communicatie en materiaaladvies op maat.
+
+---
+
+## Waarom X3DPrints
+- ⚡ **Snelle offertes** met realistische levertijd.
+- 🎯 **Precisie** voor maquettes, houders en functionele onderdelen.
+- 🌲 **Flexibel**: PLA Matte voor strakke zichtdelen, PETG voor sterkte, TPU voor schokdemping.
+
+---
+
+## Toepassingen
+- **Retail & hospitality** langs de Bredabaan: displays en maatwerkhouders.
+- **Techniek en logistiek**: reserveonderdelen, jigs en klemmen.
+- **Makers** in de groene rand: projecten voor expo's of productlanceringen.
+
+---
+
+## Praktisch
+- Upload **STL/STEP** via [contact](/contact) met aantallen en materiaalkeuze.
+- Bouwvolume tot **25 × 25 × 25 cm** per onderdeel.
+- Verzending of afhalen; tarieven op [pricing](/pricing).
+
+---
+
+## Interne links
+- [3D printen in Schoten](/3d-printen-in-schoten)
+- [3D printen in Kapellen](/3d-printen-in-kapellen)
+- [3D printen in Antwerpen](/3d-printen-in-antwerpen)
+- [Materialen & richtlijnen](/materials)

--- a/content/locations/3d-printen-in-edegem.md
+++ b/content/locations/3d-printen-in-edegem.md
@@ -1,0 +1,33 @@
+# 3D printen in Edegem: klaar voor campus en KMO
+
+**3D printen in Edegem** nodig voor een prototype, custom mount of kleine serie? Wij leveren snel richting UZA, Hof Ter Linden of je werkplek aan de Mechelsesteenweg. Verwacht heldere offertes en prints die meteen passen.
+
+---
+
+## Waarom X3DPrints
+- ⚡ **Snel**: offerte binnen één werkdag, productie in enkele werkdagen.
+- 🔒 **Consistent**: PLA Matte voor zichtwerk, PETG voor robuuste onderdelen, TPU voor flexibele dempers.
+- 🧭 **Meedenken**: advies over oriëntatie, dikte en afwerking voor indoor en outdoor gebruik.
+
+---
+
+## Voor wie in Edegem
+- **Healthcare & labo's** rond UZA: houders, fixtures en covers.
+- **Lokale ondernemers** aan Drie Eiken of de Prins Boudewijnlaan: maatwerk onderdelen en displays.
+- **Onderwijs en makers**: STEM-projecten, demo-modellen en maquettes.
+
+---
+
+## Praktisch bestellen
+- Upload **STL of STEP** via [contact](/contact) met gewenste aantallen en materiaal.
+- Bouwvolume tot **25 × 25 × 25 cm** per stuk, grotere prints worden netjes opgesplitst.
+- Verzending richting Edegem of afhalen mogelijk; tarieven staan op [pricing](/pricing).
+
+---
+
+## Interne links
+- [3D printen in Antwerpen](/3d-printen-in-antwerpen)
+- [3D printen in Mortsel](/3d-printen-in-mortsel)
+- [3D printen in Kontich](/3d-printen-in-kontich)
+- [3D printen in Hove](/3d-printen-in-hove)
+- [Materialen & richtlijnen](/materials)

--- a/content/locations/3d-printen-in-hove.md
+++ b/content/locations/3d-printen-in-hove.md
@@ -1,0 +1,32 @@
+# 3D printen in Hove: maatwerk voor lokale makers
+
+Met **3D printen in Hove** krijg je nauwkeurige onderdelen en prototypes voor projecten rond de Groenstraat en Lintsesteenweg. Wij leveren snel en denken mee over de beste materiaalkeuze.
+
+---
+
+## Pluspunten
+- ⚡ **Snel**: offerte binnen een dag, levering in enkele werkdagen.
+- 🎯 **Strak**: PLA Matte voor zichtwerk, PETG voor stevige toepassingen, TPU voor flexibele elementen.
+- 🧭 **Begeleiding**: advies over wanddikte, oriëntatie en nabewerking.
+
+---
+
+## Toepassingen
+- **Lokale ondernemers**: klemmen, houders en kleine series.
+- **Makers en bureaus**: props en maquettes voor projecten in de Zuidrand.
+- **Onderwijs**: STEM-modellen en demo-onderdelen.
+
+---
+
+## Bestellen
+- Upload **STL/STEP** via [contact](/contact) met aantallen en materiaal.
+- Tot **25 × 25 × 25 cm** per onderdeel.
+- Verzending naar Hove of afhalen; tarieven vind je op [pricing](/pricing).
+
+---
+
+## Interne links
+- [3D printen in Mortsel](/3d-printen-in-mortsel)
+- [3D printen in Edegem](/3d-printen-in-edegem)
+- [3D printen in Lint](/3d-printen-in-lint)
+- [Materialen & richtlijnen](/materials)

--- a/content/locations/3d-printen-in-kapellen.md
+++ b/content/locations/3d-printen-in-kapellen.md
@@ -1,0 +1,32 @@
+# 3D printen in Kapellen: klaar voor KMO en retail
+
+Met **3D printen in Kapellen** krijg je snelle prototypes en kleine series voor ondernemers rond Bosduin en de Essenhoutstraat. Wij verzorgen nette afwerking, heldere prijzen en advies over materiaalkeuze.
+
+---
+
+## Waarom wij
+- ⚡ **Tempo**: prijsindicatie in een dag, levering in enkele werkdagen.
+- 🧱 **Materiaalopties**: PLA Matte voor zichtwerk, PETG voor stevige onderdelen, TPU voor flexibele toepassingen.
+- 🧭 **Meedenken** over passing, layer height en post-processing.
+
+---
+
+## Ideaal voor
+- **Lokale handelaars en bureaus**: displays, maquettes en props.
+- **KMO's**: jigs, klemmen en functionele onderdelen voor machines.
+- **Makers** in Kapellen en Hoevenen: kleine reeksen of unieke stuks.
+
+---
+
+## Bestellen
+- Upload **STL/STEP** via [contact](/contact) met aantallen en gewenste kleur.
+- Tot **25 × 25 × 25 cm** per stuk; grotere delen worden opgesplitst.
+- Verzending richting Kapellen of afhalen; bekijk [pricing](/pricing).
+
+---
+
+## Interne links
+- [3D printen in Brasschaat](/3d-printen-in-brasschaat)
+- [3D printen in Schoten](/3d-printen-in-schoten)
+- [3D printen in Antwerpen](/3d-printen-in-antwerpen)
+- [Materialen & richtlijnen](/materials)

--- a/content/locations/3d-printen-in-kontich.md
+++ b/content/locations/3d-printen-in-kontich.md
@@ -1,0 +1,33 @@
+# 3D printen in Kontich: prototypes zonder omweg
+
+Voor **3D printen in Kontich** wil je snelheid en betrouwbaarheid. We leveren vanuit Herzele richting Prins Boudewijnlaan en Satenrozen, met duidelijke prijzen en prints die klaar zijn voor montage of test.
+
+---
+
+## Wat je krijgt
+- ⚡ **Snelle doorlooptijd**: offertes snel, levering in enkele werkdagen.
+- 🧱 **Sterk of strak**: PLA Matte voor nette zichtdelen, PETG voor functionele sterkte, TPU voor flex.
+- 🛠 **Engineering-minded**: we denken mee over passing, toleranties en oriëntatie.
+
+---
+
+## Toepassingen in Kontich
+- **KMO's en logistiek** langs de E19: reserveonderdelen, fixtures, productiehulpen.
+- **Design- en marketingteams**: maquettes en props voor pitches en events.
+- **Onderwijs en makers**: proof-of-concepts en STEM-projecten.
+
+---
+
+## Bestellen
+- Upload **STL/STEP** via [contact](/contact) met aantallen en materiaalvoorkeur.
+- Stukken tot **25 × 25 × 25 cm**, grotere delen worden opgesplitst en naadloos samengezet.
+- Verzending of afhalen; check [pricing](/pricing) voor tarieven.
+
+---
+
+## Interne links
+- [3D printen in Antwerpen](/3d-printen-in-antwerpen)
+- [3D printen in Edegem](/3d-printen-in-edegem)
+- [3D printen in Aartselaar](/3d-printen-in-aartselaar)
+- [3D printen in Mortsel](/3d-printen-in-mortsel)
+- [Materialen & richtlijnen](/materials)

--- a/content/locations/3d-printen-in-lint.md
+++ b/content/locations/3d-printen-in-lint.md
@@ -1,0 +1,32 @@
+# 3D printen in Lint: vlot voor spoor en KMO
+
+**3D printen in Lint** helpt je prototypes en onderdelen snel klaar te hebben voor projecten rond Lerenveld of de spoorlijn Antwerpen-Mechelen. Reken op duidelijke communicatie en nette afwerking.
+
+---
+
+## Wat je krijgt
+- ⚡ **Tempo**: offerte meestal binnen 24 uur, levering in enkele werkdagen.
+- 🧱 **Materiaalselectie**: PLA Matte voor zichtwerk, PETG voor stevige toepassingen, TPU voor flexibele delen.
+- 🧭 **Mee advies** over passing en nabewerking.
+
+---
+
+## Typische projecten
+- **KMO's en logistiek**: jigs, klemmen en houders.
+- **Makers**: maquettes, props en kleine series.
+- **Onderwijs**: modellen voor STEM of demo's.
+
+---
+
+## Bestellen
+- Upload **STL/STEP** via [contact](/contact) met aantallen en materiaal.
+- Max. **25 × 25 × 25 cm** per onderdeel.
+- Verzending of afhalen mogelijk; tarieven op [pricing](/pricing).
+
+---
+
+## Interne links
+- [3D printen in Hove](/3d-printen-in-hove)
+- [3D printen in Boechout](/3d-printen-in-boechout)
+- [3D printen in Mortsel](/3d-printen-in-mortsel)
+- [Materialen & richtlijnen](/materials)

--- a/content/locations/3d-printen-in-mortsel.md
+++ b/content/locations/3d-printen-in-mortsel.md
@@ -1,0 +1,34 @@
+# 3D printen in Mortsel: precies wat je nodig hebt
+
+Op zoek naar een partner voor **3D printen in Mortsel**? X3DPrints levert vanuit Herzele snelle, nette onderdelen richting Fort 4, de Krijgsbaan of je atelier aan de Mechelsesteenweg. Of je nu een prototype voor een pitch hebt of een functioneel onderdeel voor een machinepark, we denken mee over materiaal, tolerantie en afwerking.
+
+---
+
+## Waarom kiezen Mortsel
+- ⚡ **Snel**: offertes doorgaans binnen een werkdag, levering in enkele werkdagen.
+- 🎯 **Nauwkeurig**: strakke passing voor mounts, behuizingen en fixtures.
+- 🌦 **Materiaalkeuze**: PLA Matte voor zichtwerk, PETG voor robuuste onderdelen, TPU voor flexibele stukken.
+- 🤝 **Persoonlijk**: rechtstreeks contact, inclusief fotoupdates van je print.
+
+---
+
+## Typische toepassingen
+- **KMO's langs de Krijgsbaan**: reserveonderdelen, prototypes voor nieuwe producten.
+- **Makers en bureaus**: props, maquettes of slimme houders voor expo's en retail in de buurt van Fort 4.
+- **Onderwijs**: STEM-projecten met duidelijke richtlijnen voor sterkte en afwerking.
+
+---
+
+## Praktisch
+- Bestanden in **STL of STEP** via [contact](/contact).
+- Formaat tot **25 × 25 × 25 cm** per onderdeel, grotere stukken delen we op.
+- Verzending of afhalen op afspraak; prijzen en opties staan op [pricing](/pricing).
+
+---
+
+## Interne links
+- [3D printen in Antwerpen](/3d-printen-in-antwerpen)
+- [Materialen & richtlijnen](/materials)
+- [3D printen in Edegem](/3d-printen-in-edegem)
+- [3D printen in Kontich](/3d-printen-in-kontich)
+- [3D printen in Hove](/3d-printen-in-hove)

--- a/content/locations/3d-printen-in-rumst.md
+++ b/content/locations/3d-printen-in-rumst.md
@@ -1,0 +1,32 @@
+# 3D printen in Rumst: bouw en infrastructuur ondersteund
+
+**3D printen in Rumst** helpt je projecten tussen Rupel en Nete vooruit. We leveren nauwkeurige onderdelen en prototypes voor bouw, infra en creatieve teams.
+
+---
+
+## Waarom X3DPrints
+- ⚡ **Snel**: offerte binnen een dag, levering in enkele werkdagen.
+- 🧱 **Sterk of strak**: PLA Matte voor zichtwerk, PETG voor stevige toepassingen, TPU voor flexibele delen.
+- 🧭 **Advies**: meedenken over oriëntatie, wanddikte en nabewerking.
+
+---
+
+## Toepassingen
+- **Bouw en infra**: maatwerkhouders, klemmen en prototypes voor werven.
+- **KMO's**: jigs en kleine series voor productiehulpmiddelen.
+- **Makers en bureaus**: maquettes en props voor pitches.
+
+---
+
+## Bestellen
+- Upload **STL/STEP** via [contact](/contact) met aantallen en materiaal.
+- Tot **25 × 25 × 25 cm** per onderdeel.
+- Verzending richting Rumst of afhalen; tarieven staan op [pricing](/pricing).
+
+---
+
+## Interne links
+- [3D printen in Boom](/3d-printen-in-boom)
+- [3D printen in Aartselaar](/3d-printen-in-aartselaar)
+- [3D printen in Kontich](/3d-printen-in-kontich)
+- [Materialen & richtlijnen](/materials)

--- a/content/locations/3d-printen-in-schilde.md
+++ b/content/locations/3d-printen-in-schilde.md
@@ -1,0 +1,32 @@
+# 3D printen in Schilde: precies voor creatieve projecten
+
+**3D printen in Schilde** nodig voor een strak prototype of functioneel onderdeel? We leveren richting Turnhoutsebaan en Schildehof met duidelijke prijzen en zorg voor detail.
+
+---
+
+## Wat je mag verwachten
+- ⚡ **Snel**: offerte binnen een werkdag, print in enkele werkdagen.
+- 🎯 **Afwerking**: PLA Matte voor zichtwerk, PETG voor stevige toepassingen, TPU voor flexibele onderdelen.
+- 🧭 **Advies** over oriëntatie, wanddikte en nabewerking.
+
+---
+
+## Voor wie in Schilde
+- **Creatieve bureaus en makers**: maquettes, props en displays.
+- **KMO's** langs de Turnhoutsebaan: klemmen, jigs en functionele onderdelen.
+- **Onderwijs**: tastbare modellen voor STEM-projecten.
+
+---
+
+## Bestellen
+- Upload **STL/STEP** via [contact](/contact) met aantallen en materiaal.
+- Max. **25 × 25 × 25 cm** per stuk; grotere ontwerpen splitsen we.
+- Verzending of afhalen; zie [pricing](/pricing) voor kosten.
+
+---
+
+## Interne links
+- [3D printen in Schoten](/3d-printen-in-schoten)
+- [3D printen in Wijnegem](/3d-printen-in-wijnegem)
+- [3D printen in Antwerpen](/3d-printen-in-antwerpen)
+- [Materialen & richtlijnen](/materials)

--- a/content/locations/3d-printen-in-schoten.md
+++ b/content/locations/3d-printen-in-schoten.md
@@ -1,0 +1,32 @@
+# 3D printen in Schoten: stevige prints langs het kanaal
+
+Met **3D printen in Schoten** krijg je snel functionele onderdelen en nette prototypes voor industriezone Borgeind of creatieve projecten aan het Albertkanaal. X3DPrints combineert snelle levering met scherpe detaillering.
+
+---
+
+## Waarom X3DPrints
+- ⚡ **Tempo**: offerte binnen een werkdag, levering in enkele werkdagen.
+- 🧲 **Materiaalkeuze**: PLA Matte voor zichtwerk, PETG voor stevige tools, TPU voor flexibele bumpers.
+- 🔧 **Meedenken**: advies over oriëntatie, layer height en nabewerking.
+
+---
+
+## Typische toepassingen
+- **Industrie en logistiek**: jigs, klemmen en vervangonderdelen die tegen een stootje kunnen.
+- **Bureaus en makers**: props en maquettes voor events of pitches in de regio Schoten-Wijnegem.
+- **Onderwijs**: modellen voor STEM-projecten en robotica.
+
+---
+
+## Bestellen
+- Upload **STL of STEP** via [contact](/contact) met aantallen en gewenste kleur.
+- Maximaal **25 × 25 × 25 cm** per onderdeel; grotere stukken splitsen we.
+- Verzending richting Schoten of afhalen mogelijk; tarieven zie [pricing](/pricing).
+
+---
+
+## Interne links
+- [3D printen in Brasschaat](/3d-printen-in-brasschaat)
+- [3D printen in Kapellen](/3d-printen-in-kapellen)
+- [3D printen in Antwerpen](/3d-printen-in-antwerpen)
+- [Materialen & richtlijnen](/materials)

--- a/content/locations/3d-printen-in-wijnegem.md
+++ b/content/locations/3d-printen-in-wijnegem.md
@@ -1,0 +1,32 @@
+# 3D printen in Wijnegem: retail en industrie geholpen
+
+**3D printen in Wijnegem** is ideaal voor retailprojecten rond Wijnegem Shop Eat Enjoy en KMO's langs het Albertkanaal. X3DPrints levert snelle prototypes en functionele onderdelen met scherpe afwerking.
+
+---
+
+## Waarom samenwerken
+- ⚡ **Snel**: prijsindicatie binnen een dag, levering in enkele werkdagen.
+- 🧱 **Materiaalkeuze**: PLA Matte voor zichtwerk, PETG voor stevige toepassingen, TPU voor flexibele onderdelen.
+- 🧭 **Advies** over oriëntatie en toleranties zodat alles past.
+
+---
+
+## Toepassingen
+- **Retail & events**: displays, houders en props die opvallen.
+- **KMO's en logistiek**: jigs, klemmen en functionele onderdelen voor magazijnen.
+- **Onderwijs**: robuuste modellen voor STEM en demo's.
+
+---
+
+## Bestellen
+- Upload **STL/STEP** via [contact](/contact) met aantallen en materiaal.
+- Tot **25 × 25 × 25 cm** per stuk; grotere onderdelen delen we op.
+- Verzending richting Wijnegem of afhalen; tarieven op [pricing](/pricing).
+
+---
+
+## Interne links
+- [3D printen in Wommelgem](/3d-printen-in-wommelgem)
+- [3D printen in Schoten](/3d-printen-in-schoten)
+- [3D printen in Schilde](/3d-printen-in-schilde)
+- [Materialen & richtlijnen](/materials)

--- a/content/locations/3d-printen-in-wommelgem.md
+++ b/content/locations/3d-printen-in-wommelgem.md
@@ -1,0 +1,32 @@
+# 3D printen in Wommelgem: snel klaar voor logistiek en retail
+
+**3D printen in Wommelgem** betekent heldere prijzen, snelle levering en prints die passen. Ideaal voor projecten langs de R11, Autolei of logistieke hubs in de buurt.
+
+---
+
+## Waarom wij
+- ⚡ **Tempo**: offerte meestal binnen 24 uur, levering in enkele werkdagen.
+- 🧱 **Materialen**: PLA Matte voor nette zichtdelen, PETG voor stevige onderdelen, TPU voor flexibele toepassingen.
+- 🧭 **Meedenken**: advies over oriëntatie, laaghoogte en nabewerking.
+
+---
+
+## Toepassingen
+- **Logistiek & fulfilment**: custom mounts, labelhouders en tooling.
+- **Retail & bureaus**: displays, props en prototypes voor campagnes.
+- **Onderwijs & makers**: modellen voor STEM en testreeksen.
+
+---
+
+## Bestellen
+- Upload **STL of STEP** via [contact](/contact).
+- Max. **25 × 25 × 25 cm** per onderdeel; grotere modellen splitsen we.
+- Verzending of afhalen; zie [pricing](/pricing) voor tarieven.
+
+---
+
+## Interne links
+- [3D printen in Wijnegem](/3d-printen-in-wijnegem)
+- [3D printen in Schilde](/3d-printen-in-schilde)
+- [3D printen in Antwerpen](/3d-printen-in-antwerpen)
+- [Materialen & richtlijnen](/materials)

--- a/lib/locations.ts
+++ b/lib/locations.ts
@@ -151,6 +151,201 @@ export const locations: Location[] = [
       "Snelle 3D print service in Wilrijk voor campus Drie Eiken en bedrijven langs de A12. Materialen PLA, PETG en TPU.",
   },
   {
+    slug: "3d-printen-in-mortsel",
+    city: "Mortsel",
+    relatedPhrases: [
+      "3D print service Mortsel",
+      "rapid prototyping Mortsel",
+      "3D printing bedrijf Mortsel",
+      "3D printen nabij Mortsel",
+      "3D model laten printen Mortsel",
+    ],
+    metaDescription:
+      "Snelle 3D prints in Mortsel voor projecten rond Fort 4, de Krijgsbaan en tramverbindingen richting Antwerpen. Kies uit PLA, PETG of TPU.",
+  },
+  {
+    slug: "3d-printen-in-edegem",
+    city: "Edegem",
+    relatedPhrases: [
+      "3D print service Edegem",
+      "rapid prototyping Edegem",
+      "3D printing bedrijf Edegem",
+      "3D printen nabij Edegem",
+      "3D model laten printen Edegem",
+    ],
+    metaDescription:
+      "Professionele 3D prints in Edegem voor campus UZA, bedrijventerreinen en makers rond Hof Ter Linden. Offerte op maat met PLA, PETG of TPU.",
+  },
+  {
+    slug: "3d-printen-in-kontich",
+    city: "Kontich",
+    relatedPhrases: [
+      "3D print service Kontich",
+      "rapid prototyping Kontich",
+      "3D printing bedrijf Kontich",
+      "3D printen nabij Kontich",
+      "3D model laten printen Kontich",
+    ],
+    metaDescription:
+      "3D printen in Kontich met focus op KMO-zones Prins Boudewijnlaan en Satenrozen. Snelle levering in PLA, PETG of TPU.",
+  },
+  {
+    slug: "3d-printen-in-schoten",
+    city: "Schoten",
+    relatedPhrases: [
+      "3D print service Schoten",
+      "rapid prototyping Schoten",
+      "3D printing bedrijf Schoten",
+      "3D printen nabij Schoten",
+      "3D model laten printen Schoten",
+    ],
+    metaDescription:
+      "3D prints voor Schoten met oog op industriezone Borgeind en creatieve projecten langs het kanaal. Kies PLA, PETG of TPU.",
+  },
+  {
+    slug: "3d-printen-in-brasschaat",
+    city: "Brasschaat",
+    relatedPhrases: [
+      "3D print service Brasschaat",
+      "rapid prototyping Brasschaat",
+      "3D printing bedrijf Brasschaat",
+      "3D printen nabij Brasschaat",
+      "3D model laten printen Brasschaat",
+    ],
+    metaDescription:
+      "Nauwkeurige 3D prints in Brasschaat voor bedrijven rond de Bredabaan en projecten in de groene omgeving. PLA, PETG en TPU beschikbaar.",
+  },
+  {
+    slug: "3d-printen-in-kapellen",
+    city: "Kapellen",
+    relatedPhrases: [
+      "3D print service Kapellen",
+      "rapid prototyping Kapellen",
+      "3D printing bedrijf Kapellen",
+      "3D printen nabij Kapellen",
+      "3D model laten printen Kapellen",
+    ],
+    metaDescription:
+      "3D printing in Kapellen met snelle offertes voor ondernemers rond de Essenhoutstraat en KMO-zone Bosduin. Materialen PLA, PETG en TPU.",
+  },
+  {
+    slug: "3d-printen-in-schilde",
+    city: "Schilde",
+    relatedPhrases: [
+      "3D print service Schilde",
+      "rapid prototyping Schilde",
+      "3D printing bedrijf Schilde",
+      "3D printen nabij Schilde",
+      "3D model laten printen Schilde",
+    ],
+    metaDescription:
+      "3D printservice in Schilde voor creatieve bureaus en KMO's langs de Turnhoutsebaan. Kies PLA, PETG of TPU met snelle levering.",
+  },
+  {
+    slug: "3d-printen-in-aartselaar",
+    city: "Aartselaar",
+    relatedPhrases: [
+      "3D print service Aartselaar",
+      "rapid prototyping Aartselaar",
+      "3D printing bedrijf Aartselaar",
+      "3D printen nabij Aartselaar",
+      "3D model laten printen Aartselaar",
+    ],
+    metaDescription:
+      "3D prints in Aartselaar voor bedrijven langs de A12 en industriezone Cleydael. Beschikbaar in PLA, PETG en TPU.",
+  },
+  {
+    slug: "3d-printen-in-wommelgem",
+    city: "Wommelgem",
+    relatedPhrases: [
+      "3D print service Wommelgem",
+      "rapid prototyping Wommelgem",
+      "3D printing bedrijf Wommelgem",
+      "3D printen nabij Wommelgem",
+      "3D model laten printen Wommelgem",
+    ],
+    metaDescription:
+      "3D printen in Wommelgem met snelle verzending richting R11, Autolei en logistieke hubs. Materialen PLA, PETG en TPU.",
+  },
+  {
+    slug: "3d-printen-in-wijnegem",
+    city: "Wijnegem",
+    relatedPhrases: [
+      "3D print service Wijnegem",
+      "rapid prototyping Wijnegem",
+      "3D printing bedrijf Wijnegem",
+      "3D printen nabij Wijnegem",
+      "3D model laten printen Wijnegem",
+    ],
+    metaDescription:
+      "3D print service in Wijnegem voor retailprojecten rond Wijnegem Shop Eat Enjoy en KMO's aan het Albertkanaal. PLA, PETG, TPU.",
+  },
+  {
+    slug: "3d-printen-in-hove",
+    city: "Hove",
+    relatedPhrases: [
+      "3D print service Hove",
+      "rapid prototyping Hove",
+      "3D printing bedrijf Hove",
+      "3D printen nabij Hove",
+      "3D model laten printen Hove",
+    ],
+    metaDescription:
+      "3D prints in Hove met focus op lokale makers en ondernemers tussen Groenstraat en Lintsesteenweg. Kies PLA, PETG of TPU.",
+  },
+  {
+    slug: "3d-printen-in-lint",
+    city: "Lint",
+    relatedPhrases: [
+      "3D print service Lint",
+      "rapid prototyping Lint",
+      "3D printing bedrijf Lint",
+      "3D printen nabij Lint",
+      "3D model laten printen Lint",
+    ],
+    metaDescription:
+      "3D printen in Lint met snelle levering richting industriezone Lerenveld en de spoorverbinding Antwerpen-Mechelen. PLA, PETG en TPU beschikbaar.",
+  },
+  {
+    slug: "3d-printen-in-boechout",
+    city: "Boechout",
+    relatedPhrases: [
+      "3D print service Boechout",
+      "rapid prototyping Boechout",
+      "3D printing bedrijf Boechout",
+      "3D printen nabij Boechout",
+      "3D model laten printen Boechout",
+    ],
+    metaDescription:
+      "3D printservice in Boechout voor projecten rond Spoor Oost, Vremde en Hove. Kies PLA, PETG of TPU met heldere offertes.",
+  },
+  {
+    slug: "3d-printen-in-boom",
+    city: "Boom",
+    relatedPhrases: [
+      "3D print service Boom",
+      "rapid prototyping Boom",
+      "3D printing bedrijf Boom",
+      "3D printen nabij Boom",
+      "3D model laten printen Boom",
+    ],
+    metaDescription:
+      "3D prints in Boom voor creatieve projecten rond De Schorre en industrie langs de A12. Materialen PLA, PETG en TPU met snelle verzending.",
+  },
+  {
+    slug: "3d-printen-in-rumst",
+    city: "Rumst",
+    relatedPhrases: [
+      "3D print service Rumst",
+      "rapid prototyping Rumst",
+      "3D printing bedrijf Rumst",
+      "3D printen nabij Rumst",
+      "3D model laten printen Rumst",
+    ],
+    metaDescription:
+      "3D printen in Rumst met aandacht voor bouw- en infrastructuurprojecten tussen Rupel en Nete. Snelle offerte voor PLA, PETG of TPU.",
+  },
+  {
     slug: "3d-printen-in-herzele",
     city: "Herzele",
     relatedPhrases: [


### PR DESCRIPTION
## Wat
- Voeg Antwerpse randgemeenten toe in `lib/locations.ts` zodat sitemap en statische params de nieuwe landingspagina’s genereren.
- Schrijf nieuwe locatiecontent voor Mortsel, Edegem, Kontich, Aartselaar, Wommelgem, Wijnegem, Schilde, Schoten, Brasschaat, Kapellen, Hove, Lint, Boechout, Boom en Rumst.
- Breid de Antwerpen-pagina uit met een lijst van randgemeenten voor verdere dekking.

## Waarom
- Extra hyperlokale landingspagina’s verhogen SEO-bereik in de Antwerpse regio en zorgen voor duidelijke interne linking.

## Testplan
- [ ] Build OK
- [ ] Lint OK
- [ ] Lighthouse >= 90
- [ ] A11y (keyboard/labels/contrast)
- [ ] Responsive (sm/md/lg)
- [ ] Geen dode links/console errors
- [ ] Metadata/OG/JSON-LD up-to-date


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691f15b375ac8332b1baae7aed0d8c0e)